### PR TITLE
feat(sdk): forward all parent URL search params to iframe

### DIFF
--- a/.changeset/cuddly-pandas-find.md
+++ b/.changeset/cuddly-pandas-find.md
@@ -1,0 +1,5 @@
+---
+"@perspective-ai/sdk": minor
+---
+
+Forward all parent URL search params to iframe

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -60,36 +60,12 @@ export const BRAND_KEYS = {
 export type BrandKey = (typeof BRAND_KEYS)[keyof typeof BRAND_KEYS];
 
 // ============================================================================
-// UTM Parameters (auto-forwarded from parent URL)
-// ============================================================================
-
-export const UTM_PARAMS = [
-  "utm_source",
-  "utm_medium",
-  "utm_campaign",
-  "utm_term",
-  "utm_content",
-] as const;
-
-export type UtmParam = (typeof UTM_PARAMS)[number];
-
-// ============================================================================
-// Reserved Parameters (cannot be overridden via custom params)
+// Reserved Parameters (cannot be overridden via custom params or parent URL)
 // ============================================================================
 
 export const RESERVED_PARAMS: Set<string> = new Set([
-  PARAM_KEYS.embed,
-  PARAM_KEYS.embedType,
-  PARAM_KEYS.theme,
-  BRAND_KEYS.primary,
-  BRAND_KEYS.secondary,
-  BRAND_KEYS.bg,
-  BRAND_KEYS.text,
-  BRAND_KEYS.darkPrimary,
-  BRAND_KEYS.darkSecondary,
-  BRAND_KEYS.darkBg,
-  BRAND_KEYS.darkText,
-  ...UTM_PARAMS,
+  ...Object.values(PARAM_KEYS),
+  ...Object.values(BRAND_KEYS),
 ]);
 
 // ============================================================================

--- a/packages/sdk/src/iframe.test.ts
+++ b/packages/sdk/src/iframe.test.ts
@@ -62,6 +62,121 @@ describe("createIframe", () => {
     expect(src.searchParams.get(PARAM_KEYS.theme)).toBe("dark");
   });
 
+  it("forwards parent page search params to iframe", () => {
+    // Simulate parent page URL with search params
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      value: { ...originalLocation, search: "?ref=pricing-enterprise&foo=bar" },
+      writable: true,
+      configurable: true,
+    });
+
+    const iframe = createIframe(
+      "test-research-id",
+      "widget",
+      "https://getperspective.ai"
+    );
+
+    const src = new URL(iframe.src);
+    expect(src.searchParams.get("ref")).toBe("pricing-enterprise");
+    expect(src.searchParams.get("foo")).toBe("bar");
+
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("does not forward reserved params from parent URL", () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      value: {
+        ...originalLocation,
+        search: "?embed=false&theme=dark&ref=test",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const iframe = createIframe(
+      "test-research-id",
+      "widget",
+      "https://getperspective.ai"
+    );
+
+    const src = new URL(iframe.src);
+    // Reserved params should be set by SDK, not from parent URL
+    expect(src.searchParams.get(PARAM_KEYS.embed)).toBe("true");
+    // Non-reserved params should be forwarded
+    expect(src.searchParams.get("ref")).toBe("test");
+
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("custom params override parent URL params", () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      value: { ...originalLocation, search: "?ref=from-url&source=parent" },
+      writable: true,
+      configurable: true,
+    });
+
+    const iframe = createIframe(
+      "test-research-id",
+      "widget",
+      "https://getperspective.ai",
+      { ref: "from-custom", extra: "value" }
+    );
+
+    const src = new URL(iframe.src);
+    // Custom params should override parent URL params
+    expect(src.searchParams.get("ref")).toBe("from-custom");
+    // Parent-only params should still be forwarded
+    expect(src.searchParams.get("source")).toBe("parent");
+    // Custom-only params should be present
+    expect(src.searchParams.get("extra")).toBe("value");
+
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("forwards UTM params from parent URL", () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      value: {
+        ...originalLocation,
+        search: "?utm_source=google&utm_campaign=summer&ref=pricing",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const iframe = createIframe(
+      "test-research-id",
+      "widget",
+      "https://getperspective.ai"
+    );
+
+    const src = new URL(iframe.src);
+    expect(src.searchParams.get("utm_source")).toBe("google");
+    expect(src.searchParams.get("utm_campaign")).toBe("summer");
+    expect(src.searchParams.get("ref")).toBe("pricing");
+
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
   it("includes brand colors", () => {
     const iframe = createIframe(
       "test-research-id",

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -11,7 +11,6 @@ import type {
 } from "./types";
 import { hasDom } from "./config";
 import {
-  UTM_PARAMS,
   RESERVED_PARAMS,
   PARAM_KEYS,
   BRAND_KEYS,
@@ -63,16 +62,15 @@ function getOrCreateAnonId(): string {
   }
 }
 
-/** Collect UTM params from current page URL */
-function getUtmParams(): Record<string, string> {
+/** Collect all search params from the parent page URL (excluding reserved SDK params) */
+function getParentSearchParams(): Record<string, string> {
   if (!hasDom()) return {};
 
   const params: Record<string, string> = {};
   const searchParams = new URLSearchParams(window.location.search);
 
-  for (const key of UTM_PARAMS) {
-    const value = searchParams.get(key);
-    if (value) {
+  for (const [key, value] of searchParams.entries()) {
+    if (!RESERVED_PARAMS.has(key)) {
       params[key] = value;
     }
   }
@@ -111,9 +109,10 @@ function buildIframeUrl(
     url.searchParams.set(PARAM_KEYS.theme, themeOverride || THEME_VALUES.light);
   }
 
-  // Auto-forward UTM params from parent
-  const utmParams = getUtmParams();
-  for (const [key, value] of Object.entries(utmParams)) {
+  // Auto-forward all parent page search params (e.g. ?ref=pricing-enterprise)
+  // These are added first so that explicit customParams can override them
+  const parentParams = getParentSearchParams();
+  for (const [key, value] of Object.entries(parentParams)) {
     url.searchParams.set(key, value);
   }
 


### PR DESCRIPTION
## What's Changed

**Parent URL Param Forwarding**
- Replaced UTM-only forwarding with generic parent URL search param forwarding, so any non-reserved query param (e.g. `?ref=pricing-enterprise`) automatically propagates to the embedded iframe
- Parent params are applied first, allowing explicit `customParams` to override them

**Constants Cleanup**
- Removed `UTM_PARAMS` array and `UtmParam` type from constants
- Simplified `RESERVED_PARAMS` to use `Object.values(PARAM_KEYS)` and `Object.values(BRAND_KEYS)` instead of manually listing each key

**Tests**
- Added tests for parent search param forwarding, reserved param exclusion, custom param override precedence, and UTM param forwarding

Ref https://github.com/Perspective-AI/codebase/issues/3342