### PR TITLE
perf: preload iframes, hide-on-close, resource hints

### DIFF
--- a/.changeset/iframe-preload-hide-on-close.md
+++ b/.changeset/iframe-preload-hide-on-close.md
@@ -1,0 +1,10 @@
+---
+"@perspective-ai/sdk": minor
+---
+
+perf: preload iframes and hide-on-close for instant popup/slider reopen
+
+- Hide-on-close: popup/slider close now hides the overlay instead of destroying the iframe, so reopening is instant with conversation state preserved
+- Iframe preloading: button-triggered and auto-triggered embeds (timeout/exit-intent) preload a hidden iframe during idle time so the embed is warm when opened
+- Resource hints: inject preconnect/dns-prefetch for the embed host on SDK load
+- Embed timing instrumentation for load waterfall debugging (dev only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,6 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpm build
-
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -195,7 +195,7 @@ const { open, close } = useFloatBubble({
 });
 ```
 
-React components passed as `icon` are converted to static SVG via `renderToStaticMarkup`. See the [core SDK docs](../sdk/README.md#launcher-customization-float-bubble) for all `launcher` options.
+React components passed as `icon` are converted to static SVG markup for the core SDK. See the [core SDK docs](../sdk/README.md#launcher-customization-float-bubble) for all `launcher` options.
 
 ## Components
 
@@ -258,7 +258,6 @@ interface UsePopupOptions {
   theme?: "light" | "dark" | "system";
   channel?: "TEXT" | "VOICE" | ["TEXT", "VOICE"]; // Interaction mode
   welcomeMessage?: string; // Teaser text (float only)
-  buttonText?: string; // Trigger button text (popup/slider)
   params?: Record<string, string>;
   brand?: {
     light?: {

--- a/packages/sdk-react/src/FloatBubble.test.tsx
+++ b/packages/sdk-react/src/FloatBubble.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@perspective-ai/sdk", () => ({
     container: null,
     isOpen: false,
   })),
+  stableSerialize: vi.fn((value: unknown) => JSON.stringify(value)),
 }));
 
 import { createFloatBubble } from "@perspective-ai/sdk";
@@ -129,6 +130,20 @@ describe("FloatBubble", () => {
     expect(config.brand).toEqual({
       light: { primary: "#ff0000", bg: "#ffffff" },
       dark: { primary: "#0000ff", bg: "#000000" },
+    });
+  });
+
+  it("forwards onAuth to createFloatBubble", () => {
+    const onAuth = vi.fn();
+
+    render(<FloatBubble researchId="test-research-id" onAuth={onAuth} />);
+
+    const config = mockCreateFloatBubble.mock.calls[0]![0];
+    config.onAuth?.({ researchId: "test-research-id", token: "test-token" });
+
+    expect(onAuth).toHaveBeenCalledWith({
+      researchId: "test-research-id",
+      token: "test-token",
     });
   });
 });

--- a/packages/sdk-react/src/FloatBubble.tsx
+++ b/packages/sdk-react/src/FloatBubble.tsx
@@ -38,6 +38,7 @@ export function FloatBubble({
   onNavigate,
   onClose,
   onError,
+  onAuth,
   embedRef,
 }: FloatBubbleProps) {
   const { handle } = useFloatBubble({
@@ -54,6 +55,7 @@ export function FloatBubble({
     onNavigate,
     onClose,
     onError,
+    onAuth,
   });
 
   useEffect(() => {

--- a/packages/sdk-react/src/Fullpage.test.tsx
+++ b/packages/sdk-react/src/Fullpage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@perspective-ai/sdk", () => ({
     iframe: null,
     container: null,
   })),
+  stableSerialize: vi.fn((value: unknown) => JSON.stringify(value)),
 }));
 
 import { createFullpage } from "@perspective-ai/sdk";
@@ -64,6 +65,7 @@ describe("Fullpage", () => {
     const onClose = vi.fn();
     const onNavigate = vi.fn();
     const onError = vi.fn();
+    const onAuth = vi.fn();
 
     render(
       <Fullpage
@@ -76,6 +78,7 @@ describe("Fullpage", () => {
         onClose={onClose}
         onNavigate={onNavigate}
         onError={onError}
+        onAuth={onAuth}
       />
     );
 
@@ -85,6 +88,11 @@ describe("Fullpage", () => {
     expect(config.params).toEqual({ source: "test" });
     expect(config.theme).toBe("dark");
     expect(config.host).toBe("https://custom.example.com");
+    config.onAuth?.({ researchId: "test-research-id", token: "test-token" });
+    expect(onAuth).toHaveBeenCalledWith({
+      researchId: "test-research-id",
+      token: "test-token",
+    });
   });
 
   it("exposes handle via embedRef", () => {
@@ -142,6 +150,34 @@ describe("Fullpage", () => {
 
     expect(mockUnmount).toHaveBeenCalledTimes(1);
     expect(mockCreateFullpage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not recreate fullpage when params and brand are deeply equal", () => {
+    const { rerender } = render(
+      <Fullpage
+        researchId="test-research-id"
+        params={{ source: "test" }}
+        brand={{
+          light: { primary: "#ff0000" },
+          dark: { primary: "#0000ff" },
+        }}
+      />
+    );
+
+    expect(mockCreateFullpage).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Fullpage
+        researchId="test-research-id"
+        params={{ source: "test" }}
+        brand={{
+          light: { primary: "#ff0000" },
+          dark: { primary: "#0000ff" },
+        }}
+      />
+    );
+
+    expect(mockCreateFullpage).toHaveBeenCalledTimes(1);
   });
 
   it("passes brand colors to createFullpage", () => {

--- a/packages/sdk-react/src/Fullpage.tsx
+++ b/packages/sdk-react/src/Fullpage.tsx
@@ -5,6 +5,7 @@ import {
   type EmbedHandle,
 } from "@perspective-ai/sdk";
 import { useStableCallback } from "./hooks/useStableCallback";
+import { useStableValue } from "./hooks/useStableValue";
 
 export interface FullpageProps extends Omit<EmbedConfig, "type"> {
   /** Ref to access the embed handle for programmatic control */
@@ -26,22 +27,26 @@ export function Fullpage({
   onNavigate,
   onClose,
   onError,
+  onAuth,
   embedRef,
 }: FullpageProps) {
   const handleRef = useRef<EmbedHandle | null>(null);
 
   // Stable callbacks
+  const stableParams = useStableValue(params);
+  const stableBrand = useStableValue(brand);
   const stableOnReady = useStableCallback(onReady);
   const stableOnSubmit = useStableCallback(onSubmit);
   const stableOnNavigate = useStableCallback(onNavigate);
   const stableOnClose = useStableCallback(onClose);
   const stableOnError = useStableCallback(onError);
+  const stableOnAuth = useStableCallback(onAuth);
 
   useEffect(() => {
     const handle = createFullpage({
       researchId,
-      params,
-      brand,
+      params: stableParams,
+      brand: stableBrand,
       theme,
       host,
       onReady: stableOnReady,
@@ -49,6 +54,7 @@ export function Fullpage({
       onNavigate: stableOnNavigate,
       onClose: stableOnClose,
       onError: stableOnError,
+      onAuth: stableOnAuth,
     });
 
     handleRef.current = handle;
@@ -66,8 +72,8 @@ export function Fullpage({
     };
   }, [
     researchId,
-    params,
-    brand,
+    stableParams,
+    stableBrand,
     theme,
     host,
     stableOnReady,
@@ -75,6 +81,7 @@ export function Fullpage({
     stableOnNavigate,
     stableOnClose,
     stableOnError,
+    stableOnAuth,
     embedRef,
   ]);
 

--- a/packages/sdk-react/src/Widget.test.tsx
+++ b/packages/sdk-react/src/Widget.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@perspective-ai/sdk", () => ({
     iframe: null,
     container: null,
   })),
+  stableSerialize: vi.fn((value: unknown) => JSON.stringify(value)),
 }));
 
 import { createWidget } from "@perspective-ai/sdk";
@@ -67,6 +68,7 @@ describe("Widget", () => {
   it("calls createWidget with correct config", () => {
     const onReady = vi.fn();
     const onSubmit = vi.fn();
+    const onAuth = vi.fn();
 
     render(
       <Widget
@@ -76,6 +78,7 @@ describe("Widget", () => {
         host="https://custom.example.com"
         onReady={onReady}
         onSubmit={onSubmit}
+        onAuth={onAuth}
       />
     );
 
@@ -86,6 +89,11 @@ describe("Widget", () => {
     expect(config.params).toEqual({ source: "test" });
     expect(config.theme).toBe("dark");
     expect(config.host).toBe("https://custom.example.com");
+    config.onAuth?.({ researchId: "test-research-id", token: "test-token" });
+    expect(onAuth).toHaveBeenCalledWith({
+      researchId: "test-research-id",
+      token: "test-token",
+    });
   });
 
   it("calls unmount on cleanup", () => {
@@ -150,6 +158,34 @@ describe("Widget", () => {
     rerender(<Widget researchId="research-2" />);
 
     expect(mockCreateWidget).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not recreate the widget when params and brand are deeply equal", () => {
+    const { rerender } = render(
+      <Widget
+        researchId="test-research-id"
+        params={{ source: "test" }}
+        brand={{
+          light: { primary: "#ff0000" },
+          dark: { primary: "#0000ff" },
+        }}
+      />
+    );
+
+    expect(mockCreateWidget).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Widget
+        researchId="test-research-id"
+        params={{ source: "test" }}
+        brand={{
+          light: { primary: "#ff0000" },
+          dark: { primary: "#0000ff" },
+        }}
+      />
+    );
+
+    expect(mockCreateWidget).toHaveBeenCalledTimes(1);
   });
 
   it("passes additional div props", () => {

--- a/packages/sdk-react/src/Widget.tsx
+++ b/packages/sdk-react/src/Widget.tsx
@@ -5,6 +5,7 @@ import {
   type EmbedHandle,
 } from "@perspective-ai/sdk";
 import { useStableCallback } from "./hooks/useStableCallback";
+import { useStableValue } from "./hooks/useStableValue";
 
 export interface WidgetProps
   extends
@@ -29,6 +30,7 @@ export function Widget({
   onNavigate,
   onClose,
   onError,
+  onAuth,
   embedRef,
   className,
   style,
@@ -38,11 +40,14 @@ export function Widget({
   const handleRef = useRef<EmbedHandle | null>(null);
 
   // Stable callbacks to avoid re-mounting on callback changes
+  const stableParams = useStableValue(params);
+  const stableBrand = useStableValue(brand);
   const stableOnReady = useStableCallback(onReady);
   const stableOnSubmit = useStableCallback(onSubmit);
   const stableOnNavigate = useStableCallback(onNavigate);
   const stableOnClose = useStableCallback(onClose);
   const stableOnError = useStableCallback(onError);
+  const stableOnAuth = useStableCallback(onAuth);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -50,8 +55,8 @@ export function Widget({
 
     const handle = createWidget(container, {
       researchId,
-      params,
-      brand,
+      params: stableParams,
+      brand: stableBrand,
       theme,
       host,
       onReady: stableOnReady,
@@ -59,6 +64,7 @@ export function Widget({
       onNavigate: stableOnNavigate,
       onClose: stableOnClose,
       onError: stableOnError,
+      onAuth: stableOnAuth,
     });
 
     handleRef.current = handle;
@@ -76,8 +82,8 @@ export function Widget({
     };
   }, [
     researchId,
-    params,
-    brand,
+    stableParams,
+    stableBrand,
     theme,
     host,
     stableOnReady,
@@ -85,6 +91,7 @@ export function Widget({
     stableOnNavigate,
     stableOnClose,
     stableOnError,
+    stableOnAuth,
     embedRef,
   ]);
 

--- a/packages/sdk-react/src/hooks/renderLauncherIcon.ts
+++ b/packages/sdk-react/src/hooks/renderLauncherIcon.ts
@@ -1,0 +1,8 @@
+import type { ReactElement } from "react";
+
+export async function renderLauncherIconToSvg(
+  icon: ReactElement
+): Promise<string> {
+  const { renderToStaticMarkup } = await import("react-dom/server.browser");
+  return renderToStaticMarkup(icon);
+}

--- a/packages/sdk-react/src/hooks/useAutoOpen.test.ts
+++ b/packages/sdk-react/src/hooks/useAutoOpen.test.ts
@@ -12,34 +12,38 @@ vi.mock("@perspective-ai/sdk", () => ({
     iframe: null,
     container: null,
   })),
-  setupTrigger: vi.fn(() => vi.fn()),
+  preloadIframe: vi.fn(),
+  destroyPreloadedByType: vi.fn(),
+  setupAutoOpenPopup: vi.fn(() => vi.fn()),
   shouldShow: vi.fn(() => true),
-  markShown: vi.fn(),
-}));
-
-// useStableCallback just passes through in tests
-vi.mock("./useStableCallback", () => ({
-  useStableCallback: (cb: unknown) => cb,
+  getHost: vi.fn((host?: string) => host ?? "https://getperspective.ai"),
+  stableSerialize: vi.fn((value: unknown) => JSON.stringify(value)),
 }));
 
 import {
   openPopup,
-  setupTrigger,
+  preloadIframe,
+  destroyPreloadedByType,
+  setupAutoOpenPopup,
   shouldShow,
-  markShown,
+  getHost,
 } from "@perspective-ai/sdk";
 
 const mockOpenPopup = vi.mocked(openPopup);
-const mockSetupTrigger = vi.mocked(setupTrigger);
+const mockPreloadIframe = vi.mocked(preloadIframe);
+const mockDestroyPreloadedByType = vi.mocked(destroyPreloadedByType);
+const mockSetupAutoOpenPopup = vi.mocked(setupAutoOpenPopup);
 const mockShouldShow = vi.mocked(shouldShow);
-const mockMarkShown = vi.mocked(markShown);
+const mockGetHost = vi.mocked(getHost);
 
 describe("useAutoOpen", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Restore defaults after clearAllMocks resets implementations
     mockShouldShow.mockReturnValue(true);
-    mockSetupTrigger.mockReturnValue(vi.fn());
+    mockSetupAutoOpenPopup.mockReturnValue(vi.fn());
+    mockGetHost.mockImplementation(
+      (host?: string) => host ?? "https://getperspective.ai"
+    );
     vi.useFakeTimers();
   });
 
@@ -48,7 +52,7 @@ describe("useAutoOpen", () => {
     cleanup();
   });
 
-  it("calls setupTrigger on mount when shouldShow returns true", () => {
+  it("preloads the popup and registers the trigger on mount", () => {
     renderHook(() =>
       useAutoOpen({
         researchId: "test-id",
@@ -57,13 +61,24 @@ describe("useAutoOpen", () => {
     );
 
     expect(mockShouldShow).toHaveBeenCalledWith("test-id", "session");
-    expect(mockSetupTrigger).toHaveBeenCalledWith(
-      { type: "timeout", delay: 5000 },
-      expect.any(Function)
+    expect(mockGetHost).toHaveBeenCalledWith(undefined);
+    expect(mockPreloadIframe).toHaveBeenCalledWith(
+      "test-id",
+      "popup",
+      "https://getperspective.ai",
+      undefined,
+      undefined,
+      undefined
+    );
+    expect(mockSetupAutoOpenPopup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        researchId: "test-id",
+        trigger: { type: "timeout", delay: 5000 },
+      })
     );
   });
 
-  it("does not call setupTrigger when shouldShow returns false", () => {
+  it("does not preload or register a trigger when shouldShow returns false", () => {
     mockShouldShow.mockReturnValue(false);
 
     renderHook(() =>
@@ -73,13 +88,19 @@ describe("useAutoOpen", () => {
       })
     );
 
-    expect(mockSetupTrigger).not.toHaveBeenCalled();
+    expect(mockPreloadIframe).not.toHaveBeenCalled();
+    expect(mockSetupAutoOpenPopup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        researchId: "test-id",
+        trigger: { type: "timeout", delay: 5000 },
+      })
+    );
   });
 
-  it("calls markShown and openPopup when trigger fires", () => {
-    let triggerCallback: () => void;
-    mockSetupTrigger.mockImplementation((_config, cb) => {
-      triggerCallback = cb;
+  it("updates triggered when the shared auto-open controller fires", () => {
+    let onTriggered: (() => void) | undefined;
+    mockSetupAutoOpenPopup.mockImplementation((options) => {
+      onTriggered = options.onTriggered;
       return vi.fn();
     });
 
@@ -93,19 +114,15 @@ describe("useAutoOpen", () => {
 
     expect(result.current.triggered).toBe(false);
 
-    act(() => triggerCallback!());
+    act(() => onTriggered?.());
 
-    expect(mockMarkShown).toHaveBeenCalledWith("test-id", "visitor");
-    expect(mockOpenPopup).toHaveBeenCalledWith(
-      expect.objectContaining({ researchId: "test-id" })
-    );
     expect(result.current.triggered).toBe(true);
   });
 
-  it("only fires once even if trigger callback called multiple times", () => {
-    let triggerCallback: () => void;
-    mockSetupTrigger.mockImplementation((_config, cb) => {
-      triggerCallback = cb;
+  it("only fires once even if the trigger callback runs multiple times", () => {
+    let onTriggered: (() => void) | undefined;
+    mockSetupAutoOpenPopup.mockImplementation((options) => {
+      onTriggered = options.onTriggered;
       return vi.fn();
     });
 
@@ -116,10 +133,9 @@ describe("useAutoOpen", () => {
       })
     );
 
-    act(() => triggerCallback!());
-    act(() => triggerCallback!());
+    act(() => onTriggered?.());
+    act(() => onTriggered?.());
 
-    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
     expect(result.current.triggered).toBe(true);
   });
 
@@ -134,9 +150,9 @@ describe("useAutoOpen", () => {
     expect(mockShouldShow).toHaveBeenCalledWith("test-id", "session");
   });
 
-  it("calls cleanup on unmount", () => {
+  it("cleans up the trigger and preload on unmount", () => {
     const mockCleanup = vi.fn();
-    mockSetupTrigger.mockReturnValue(mockCleanup);
+    mockSetupAutoOpenPopup.mockReturnValue(mockCleanup);
 
     const { unmount } = renderHook(() =>
       useAutoOpen({
@@ -148,11 +164,12 @@ describe("useAutoOpen", () => {
     unmount();
 
     expect(mockCleanup).toHaveBeenCalled();
+    expect(mockDestroyPreloadedByType).toHaveBeenCalledWith("test-id", "popup");
   });
 
-  it("cancel() stops the trigger", () => {
+  it("cancel() stops the trigger and removes the preload", () => {
     const mockCleanup = vi.fn();
-    mockSetupTrigger.mockReturnValue(mockCleanup);
+    mockSetupAutoOpenPopup.mockReturnValue(mockCleanup);
 
     const { result } = renderHook(() =>
       useAutoOpen({
@@ -161,8 +178,120 @@ describe("useAutoOpen", () => {
       })
     );
 
-    result.current.cancel();
+    act(() => {
+      result.current.cancel();
+    });
 
     expect(mockCleanup).toHaveBeenCalled();
+    expect(mockDestroyPreloadedByType).toHaveBeenCalledWith("test-id", "popup");
+  });
+
+  it("refreshes the preload when iframe-defining config changes", () => {
+    const { rerender } = renderHook(
+      ({ params, theme }) =>
+        useAutoOpen({
+          researchId: "test-id",
+          trigger: { type: "timeout", delay: 5000 },
+          params,
+          theme,
+        }),
+      {
+        initialProps: {
+          params: { source: "first" },
+          theme: "light" as "light" | "dark",
+        },
+      }
+    );
+
+    expect(mockPreloadIframe).toHaveBeenCalledTimes(1);
+    expect(mockSetupAutoOpenPopup).toHaveBeenCalledTimes(1);
+
+    rerender({
+      params: { source: "second" },
+      theme: "dark" as const,
+    });
+
+    expect(mockPreloadIframe).toHaveBeenCalledTimes(2);
+    expect(mockPreloadIframe).toHaveBeenLastCalledWith(
+      "test-id",
+      "popup",
+      "https://getperspective.ai",
+      { source: "second" },
+      undefined,
+      "dark"
+    );
+    expect(mockDestroyPreloadedByType).toHaveBeenCalledWith("test-id", "popup");
+    expect(mockSetupAutoOpenPopup).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the latest popup config to the shared auto-open controller", () => {
+    let onOpen: (() => void) | undefined;
+    mockSetupAutoOpenPopup.mockImplementation((options) => {
+      onOpen = options.onOpen;
+      return vi.fn();
+    });
+
+    const { rerender } = renderHook(
+      ({ params, host }) =>
+        useAutoOpen({
+          researchId: "test-id",
+          trigger: { type: "timeout", delay: 5000 },
+          params,
+          host,
+        }),
+      {
+        initialProps: {
+          params: { source: "first" },
+          host: "https://first.example.com",
+        },
+      }
+    );
+
+    rerender({
+      params: { source: "second" },
+      host: "https://second.example.com",
+    });
+
+    act(() => onOpen?.());
+
+    expect(mockOpenPopup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        researchId: "test-id",
+        params: { source: "second" },
+        host: "https://second.example.com",
+      })
+    );
+    expect(mockSetupAutoOpenPopup).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        researchId: "test-id",
+        trigger: { type: "timeout", delay: 5000 },
+        onOpen: expect.any(Function),
+      })
+    );
+  });
+
+  it("passes disableClose to openPopup when the trigger fires", () => {
+    let onOpen: (() => void) | undefined;
+    mockSetupAutoOpenPopup.mockImplementation((options) => {
+      onOpen = options.onOpen;
+      return vi.fn();
+    });
+
+    renderHook(() =>
+      useAutoOpen({
+        researchId: "test-id",
+        trigger: { type: "timeout", delay: 5000 },
+        disableClose: true,
+      })
+    );
+
+    act(() => onOpen?.());
+
+    expect(mockOpenPopup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        researchId: "test-id",
+        disableClose: true,
+      })
+    );
   });
 });

--- a/packages/sdk-react/src/hooks/useAutoOpen.ts
+++ b/packages/sdk-react/src/hooks/useAutoOpen.ts
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import {
   openPopup,
-  setupTrigger,
+  preloadIframe,
+  destroyPreloadedByType,
+  setupAutoOpenPopup,
   shouldShow,
-  markShown,
+  getHost,
 } from "@perspective-ai/sdk";
 import type { EmbedConfig, TriggerConfig, ShowOnce } from "@perspective-ai/sdk";
 import { useStableCallback } from "./useStableCallback";
+import { useStableValue } from "./useStableValue";
 
 export interface UseAutoOpenOptions extends Omit<
   EmbedConfig,
@@ -24,26 +27,80 @@ export interface UseAutoOpenReturn {
 }
 
 export function useAutoOpen(options: UseAutoOpenOptions): UseAutoOpenReturn {
-  const { trigger, showOnce = "session", researchId, ...embedConfig } = options;
+  const {
+    trigger,
+    showOnce = "session",
+    researchId,
+    params,
+    brand,
+    theme,
+    host,
+    disableClose,
+    onReady,
+    onSubmit,
+    onNavigate,
+    onClose,
+    onError,
+    onAuth,
+    channel,
+    welcomeMessage,
+  } = options;
   const cleanupRef = useRef<(() => void) | null>(null);
   const [triggered, setTriggered] = useState(false);
   const triggerDelay = trigger.type === "timeout" ? trigger.delay : undefined;
-
-  // Fix #5: useStableCallback so the trigger always calls with latest config
-  const stableOnTrigger = useStableCallback(() => {
-    markShown(researchId, showOnce);
-    openPopup({ researchId, ...embedConfig });
+  const stableParams = useStableValue(params);
+  const stableBrand = useStableValue(brand);
+  const stableOnReady = useStableCallback(onReady);
+  const stableOnSubmit = useStableCallback(onSubmit);
+  const stableOnNavigate = useStableCallback(onNavigate);
+  const stableOnClose = useStableCallback(onClose);
+  const stableOnError = useStableCallback(onError);
+  const stableOnAuth = useStableCallback(onAuth);
+  const stableOpenPopup = useStableCallback(() => {
+    openPopup({
+      researchId,
+      params: stableParams,
+      brand: stableBrand,
+      theme,
+      host,
+      disableClose,
+      onReady: stableOnReady,
+      onSubmit: stableOnSubmit,
+      onNavigate: stableOnNavigate,
+      onClose: stableOnClose,
+      onError: stableOnError,
+      onAuth: stableOnAuth,
+      channel,
+      welcomeMessage,
+    });
   });
 
   useEffect(() => {
-    if (!shouldShow(researchId, showOnce)) return;
+    if (triggered || !shouldShow(researchId, showOnce)) return;
 
-    cleanupRef.current = setupTrigger(trigger, () => {
-      setTriggered((prev) => {
-        if (prev) return prev; // already fired
-        stableOnTrigger();
-        return true;
-      });
+    preloadIframe(
+      researchId,
+      "popup",
+      getHost(host),
+      stableParams,
+      stableBrand,
+      theme
+    );
+
+    return () => {
+      destroyPreloadedByType(researchId, "popup");
+    };
+  }, [researchId, showOnce, host, stableParams, stableBrand, theme, triggered]);
+
+  useEffect(() => {
+    cleanupRef.current = setupAutoOpenPopup({
+      trigger,
+      showOnce,
+      researchId,
+      onOpen: stableOpenPopup,
+      onTriggered: () => {
+        setTriggered(true);
+      },
     });
 
     return () => {
@@ -57,7 +114,8 @@ export function useAutoOpen(options: UseAutoOpenOptions): UseAutoOpenReturn {
   const cancel = useCallback(() => {
     cleanupRef.current?.();
     cleanupRef.current = null;
-  }, []);
+    destroyPreloadedByType(researchId, "popup");
+  }, [researchId]);
 
   return { cancel, triggered };
 }

--- a/packages/sdk-react/src/hooks/useFloatBubble.test.ts
+++ b/packages/sdk-react/src/hooks/useFloatBubble.test.ts
@@ -1,39 +1,70 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, cleanup, act } from "@testing-library/react";
+import { renderHook, cleanup, act, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import type { FloatHandle, ThemeValue } from "@perspective-ai/sdk";
 import { useFloatBubble } from "./useFloatBubble";
 
-const mockOpen = vi.fn();
-const mockClose = vi.fn();
-const mockUnmount = vi.fn();
-const mockToggle = vi.fn();
-const mockDestroy = vi.fn();
-const mockUpdate = vi.fn();
-
-const stableMockHandle = {
-  open: mockOpen,
-  close: mockClose,
-  unmount: mockUnmount,
-  toggle: mockToggle,
-  destroy: mockDestroy,
-  update: mockUpdate,
-  isOpen: false,
-  researchId: "test-research-id",
-  type: "float" as const,
-  iframe: null,
-  container: null,
+type MockFloatHandle = FloatHandle & {
+  open: ReturnType<typeof vi.fn<() => void>>;
+  close: ReturnType<typeof vi.fn<() => void>>;
+  unmount: ReturnType<typeof vi.fn<() => void>>;
+  toggle: ReturnType<typeof vi.fn<() => void>>;
+  destroy: ReturnType<typeof vi.fn<() => void>>;
+  update: ReturnType<typeof vi.fn<FloatHandle["update"]>>;
 };
 
+function createMockHandle(): MockFloatHandle {
+  let isOpen = false;
+  const handle: MockFloatHandle = {
+    open: vi.fn<() => void>(() => {
+      isOpen = true;
+    }),
+    close: vi.fn<() => void>(() => {
+      isOpen = false;
+    }),
+    unmount: vi.fn<() => void>(),
+    toggle: vi.fn<() => void>(),
+    destroy: vi.fn<() => void>(),
+    update: vi.fn<FloatHandle["update"]>(),
+    get isOpen() {
+      return isOpen;
+    },
+    researchId: "test-research-id",
+    type: "float",
+    iframe: null,
+    container: null,
+  };
+
+  return handle;
+}
+
+const createdHandles: MockFloatHandle[] = [];
+
 vi.mock("@perspective-ai/sdk", () => ({
-  createFloatBubble: vi.fn(() => stableMockHandle),
+  createFloatBubble: vi.fn(),
+  stableSerialize: vi.fn((value: unknown) => JSON.stringify(value)),
+}));
+
+vi.mock("./renderLauncherIcon", () => ({
+  renderLauncherIconToSvg: vi.fn(
+    async () => '<svg data-icon="test-launcher"></svg>'
+  ),
 }));
 
 import { createFloatBubble } from "@perspective-ai/sdk";
+import { renderLauncherIconToSvg } from "./renderLauncherIcon";
 const mockCreateFloatBubble = vi.mocked(createFloatBubble);
+const mockRenderLauncherIconToSvg = vi.mocked(renderLauncherIconToSvg);
 
 describe("useFloatBubble", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    stableMockHandle.isOpen = false;
+    createdHandles.length = 0;
+    mockCreateFloatBubble.mockImplementation(() => {
+      const handle = createMockHandle();
+      createdHandles.push(handle);
+      return handle;
+    });
   });
 
   afterEach(() => {
@@ -52,7 +83,7 @@ describe("useFloatBubble", () => {
 
     unmount();
 
-    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(createdHandles[0]?.unmount).toHaveBeenCalledTimes(1);
   });
 
   it("returns expected interface", () => {
@@ -81,11 +112,97 @@ describe("useFloatBubble", () => {
       result.current.unmount();
     });
 
-    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(createdHandles[0]?.unmount).toHaveBeenCalledTimes(1);
     expect(result.current.handle).toBeNull();
 
     unmount();
 
-    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(createdHandles[0]?.unmount).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps controlled float bubble open when recreated while open", () => {
+    const initialProps: { theme: ThemeValue; open: boolean } = {
+      theme: "light",
+      open: true,
+    };
+
+    const { rerender } = renderHook(
+      ({ theme, open }: { theme: ThemeValue; open: boolean }) =>
+        useFloatBubble({
+          researchId: "test-research-id",
+          theme,
+          open,
+        }),
+      {
+        initialProps,
+      }
+    );
+
+    const firstHandle = createdHandles[0]!;
+    expect(firstHandle.open).toHaveBeenCalledTimes(1);
+
+    rerender({ theme: "dark", open: true });
+
+    const secondHandle = createdHandles[1]!;
+    expect(firstHandle.unmount).toHaveBeenCalledTimes(1);
+    expect(secondHandle.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps uncontrolled float bubble open when recreated while open", () => {
+    const initialProps: { theme: ThemeValue } = { theme: "light" };
+
+    const { result, rerender } = renderHook(
+      ({ theme }: { theme: ThemeValue }) =>
+        useFloatBubble({
+          researchId: "test-research-id",
+          theme,
+        }),
+      {
+        initialProps,
+      }
+    );
+
+    const firstHandle = createdHandles[0]!;
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(firstHandle.open).toHaveBeenCalledTimes(1);
+
+    rerender({ theme: "dark" });
+
+    const secondHandle = createdHandles[1]!;
+    expect(firstHandle.unmount).toHaveBeenCalledTimes(1);
+    expect(secondHandle.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes React launcher icons to SVG markup", async () => {
+    renderHook(() =>
+      useFloatBubble({
+        researchId: "test-research-id",
+        launcher: {
+          icon: createElement("svg", { "data-icon": "test-launcher" }),
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockRenderLauncherIconToSvg).toHaveBeenCalled();
+      const latestCall =
+        mockCreateFloatBubble.mock.calls[
+          mockCreateFloatBubble.mock.calls.length - 1
+        ];
+      const launcher = latestCall?.[0].launcher;
+      const svgMarkup =
+        launcher &&
+        typeof launcher.icon === "object" &&
+        launcher.icon !== null &&
+        "svg" in launcher.icon
+          ? launcher.icon.svg
+          : "";
+
+      expect(svgMarkup).toContain('data-icon="test-launcher"');
+    });
   });
 });

--- a/packages/sdk-react/src/hooks/useFloatBubble.ts
+++ b/packages/sdk-react/src/hooks/useFloatBubble.ts
@@ -5,6 +5,7 @@ import {
   useRef,
   useMemo,
   isValidElement,
+  type ReactElement,
 } from "react";
 import type { ReactNode } from "react";
 import {
@@ -12,9 +13,11 @@ import {
   type EmbedConfig,
   type FloatHandle,
   type LauncherConfig,
+  stableSerialize,
 } from "@perspective-ai/sdk";
-import { renderToStaticMarkup } from "react-dom/server";
+import { renderLauncherIconToSvg } from "./renderLauncherIcon";
 import { useStableCallback } from "./useStableCallback";
+import { useStableValue } from "./useStableValue";
 
 /** Launcher config with React support — icon accepts ReactNode in addition to SDK types */
 export interface LauncherConfigReact extends Omit<LauncherConfig, "icon"> {
@@ -50,6 +53,78 @@ export interface UseFloatBubbleReturn {
   handle: FloatHandle | null;
 }
 
+type LauncherResolution = {
+  launcher: EmbedConfig["launcher"] | undefined;
+  reactIcon: ReactElement | null;
+};
+
+function useStableReactElement(
+  element: ReactElement | null
+): ReactElement | null {
+  const ref = useRef(element);
+  const propsSignature = element ? stableSerialize(element.props) : null;
+  const previousPropsSignature = useRef(propsSignature);
+
+  const didChange =
+    ref.current?.type !== element?.type ||
+    ref.current?.key !== element?.key ||
+    previousPropsSignature.current !== propsSignature;
+
+  if (didChange) {
+    ref.current = element;
+    previousPropsSignature.current = propsSignature;
+  }
+
+  return ref.current;
+}
+
+function isLauncherIcon(
+  icon: LauncherConfigReact["icon"]
+): icon is LauncherConfig["icon"] {
+  if (icon === "default" || icon === "avatar") {
+    return true;
+  }
+
+  return Boolean(
+    icon &&
+    typeof icon === "object" &&
+    (("url" in icon && typeof icon.url === "string") ||
+      ("svg" in icon && typeof icon.svg === "string"))
+  );
+}
+
+function resolveLauncherConfig(
+  launcher: LauncherConfigReact | undefined
+): LauncherResolution {
+  if (!launcher) {
+    return { launcher: undefined, reactIcon: null };
+  }
+
+  const { icon, ...rest } = launcher;
+  const baseLauncher: Omit<LauncherConfig, "icon"> | undefined =
+    Object.keys(rest).length > 0 ? rest : undefined;
+
+  if (
+    icon === false ||
+    icon === null ||
+    icon === undefined ||
+    icon === 0 ||
+    icon === ""
+  ) {
+    return { launcher: baseLauncher, reactIcon: null };
+  }
+
+  if (isValidElement(icon)) {
+    return { launcher: baseLauncher, reactIcon: icon };
+  }
+
+  if (isLauncherIcon(icon)) {
+    return { launcher: { ...rest, icon }, reactIcon: null };
+  }
+
+  return { launcher: baseLauncher, reactIcon: null };
+}
+
 /**
  * Headless hook for float bubble lifecycle management.
  * Creates a floating bubble button that expands into a chat window.
@@ -82,6 +157,7 @@ export function useFloatBubble(
     onNavigate,
     onClose,
     onError,
+    onAuth,
     open: controlledOpen,
     onOpenChange,
   } = options;
@@ -91,11 +167,45 @@ export function useFloatBubble(
   const handleRef = useRef<FloatHandle | null>(null);
 
   const isControlled = controlledOpen !== undefined;
+  const currentOpen = isControlled
+    ? controlledOpen
+    : (handleRef.current?.isOpen ?? internalOpen);
+  const openStateRef = useRef(Boolean(currentOpen));
+  openStateRef.current = Boolean(currentOpen);
+
+  const stableParams = useStableValue(params);
+  const stableBrand = useStableValue(brand);
+  const rawReactLauncherIcon =
+    launcher && isValidElement(launcher.icon) ? launcher.icon : null;
+  const stableLauncher = useStableValue(
+    launcher
+      ? {
+          ...launcher,
+          icon: rawReactLauncherIcon ? undefined : launcher.icon,
+        }
+      : undefined
+  );
+  const stableReactLauncherIcon = useStableReactElement(rawReactLauncherIcon);
 
   const stableOnReady = useStableCallback(onReady);
   const stableOnSubmit = useStableCallback(onSubmit);
   const stableOnNavigate = useStableCallback(onNavigate);
   const stableOnError = useStableCallback(onError);
+  const stableOnAuth = useStableCallback(onAuth);
+  const launcherResolution = useMemo(
+    () =>
+      resolveLauncherConfig(
+        stableReactLauncherIcon
+          ? { ...stableLauncher, icon: stableReactLauncherIcon }
+          : stableLauncher
+      ),
+    [stableLauncher, stableReactLauncherIcon]
+  );
+  const baseLauncher = launcherResolution.launcher;
+  const reactLauncherIcon = launcherResolution.reactIcon;
+  const [resolvedLauncher, setResolvedLauncher] = useState<
+    EmbedConfig["launcher"] | undefined
+  >(launcherResolution.launcher);
 
   const handleClose = useCallback(() => {
     setInternalOpen(false);
@@ -107,39 +217,41 @@ export function useFloatBubble(
 
   const stableOnClose = useStableCallback(handleClose);
 
-  // Resolve ReactNode icons to SVG strings for the core SDK
-  const resolvedLauncher = useMemo((): EmbedConfig["launcher"] | undefined => {
-    if (!launcher) return undefined;
-    const { icon, ...rest } = launcher;
-    // Filter out falsy ReactNode values (e.g., `condition && <Icon />` producing `false`)
-    if (
-      icon === false ||
-      icon === null ||
-      icon === undefined ||
-      icon === 0 ||
-      icon === ""
-    ) {
-      return Object.keys(rest).length > 0 ? rest : undefined;
+  useEffect(() => {
+    let cancelled = false;
+
+    setResolvedLauncher(baseLauncher);
+
+    if (!reactLauncherIcon) {
+      return;
     }
-    if (isValidElement(icon)) {
-      return { ...rest, icon: { svg: renderToStaticMarkup(icon) } };
-    }
-    // Only pass through valid LauncherIcon values to core SDK
-    if (icon === "default" || icon === "avatar") {
-      return { ...rest, icon: icon as "default" | "avatar" };
-    }
-    if (typeof icon === "object" && ("url" in icon || "svg" in icon)) {
-      return { ...rest, icon: icon as { url: string } | { svg: string } };
-    }
-    // Unrecognized icon value (truthy primitives, arrays, etc.) — ignore it
-    return Object.keys(rest).length > 0 ? rest : undefined;
-  }, [launcher]);
+
+    void renderLauncherIconToSvg(reactLauncherIcon)
+      .then((svg) => {
+        if (cancelled) return;
+        setResolvedLauncher({
+          ...baseLauncher,
+          icon: { svg },
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setResolvedLauncher(baseLauncher);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseLauncher, reactLauncherIcon]);
 
   useEffect(() => {
+    // Preserve the visible/open state if the float handle is recreated because
+    // an iframe-defining input changed.
+    const shouldStartOpen = openStateRef.current;
     const newHandle = createFloatBubble({
       researchId,
-      params,
-      brand,
+      params: stableParams,
+      brand: stableBrand,
       theme,
       host,
       channel,
@@ -150,7 +262,12 @@ export function useFloatBubble(
       onNavigate: stableOnNavigate,
       onClose: stableOnClose,
       onError: stableOnError,
+      onAuth: stableOnAuth,
     });
+
+    if (shouldStartOpen) {
+      newHandle.open();
+    }
 
     handleRef.current = newHandle;
     setHandle(newHandle);
@@ -164,8 +281,8 @@ export function useFloatBubble(
     };
   }, [
     researchId,
-    params,
-    brand,
+    stableParams,
+    stableBrand,
     theme,
     host,
     channel,
@@ -176,6 +293,7 @@ export function useFloatBubble(
     stableOnNavigate,
     stableOnClose,
     stableOnError,
+    stableOnAuth,
   ]);
 
   useEffect(() => {

--- a/packages/sdk-react/src/hooks/usePopup.test.ts
+++ b/packages/sdk-react/src/hooks/usePopup.test.ts
@@ -2,33 +2,103 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, cleanup } from "@testing-library/react";
 import { usePopup } from "./usePopup";
 
-const { mockDestroy, mockUnmount, mockUpdate, mockGetPersistedOpenState } =
-  vi.hoisted(() => ({
-    mockDestroy: vi.fn(),
-    mockUnmount: vi.fn(),
-    mockUpdate: vi.fn(),
-    mockGetPersistedOpenState: vi.fn(),
-  }));
+const {
+  mockDestroy,
+  mockUnmount,
+  mockUpdate,
+  mockShow,
+  mockHide,
+  mockGetPersistedOpenState,
+  sdkCloseRef,
+} = vi.hoisted(() => ({
+  mockDestroy: vi.fn(),
+  mockUnmount: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockShow: vi.fn(),
+  mockHide: vi.fn(),
+  mockGetPersistedOpenState: vi.fn(),
+  sdkCloseRef: { current: null as (() => void) | null },
+}));
 
 vi.mock("@perspective-ai/sdk", () => ({
   getPersistedOpenState: mockGetPersistedOpenState,
-  openPopup: vi.fn(() => ({
-    unmount: mockUnmount,
-    update: mockUpdate,
-    destroy: mockDestroy,
-    researchId: "test-research-id",
-    type: "popup",
-    iframe: null,
-    container: null,
-  })),
+  stableSerialize: vi.fn((value: unknown) => JSON.stringify(value)),
+  openPopup: vi.fn(
+    (config: {
+      researchId?: string;
+      onClose?: () => void;
+      host?: string;
+      _startHidden?: boolean;
+    }) => {
+      const currentConfig = { ...config };
+      let open = !config._startHidden;
+
+      const show = () => {
+        if (open) return;
+        mockShow();
+        open = true;
+      };
+
+      const hide = () => {
+        if (!open) return;
+        mockHide();
+        open = false;
+        currentConfig.onClose?.();
+      };
+
+      const unmount = () => {
+        mockUnmount();
+        open = false;
+      };
+
+      const destroy = () => {
+        mockDestroy();
+        const wasOpen = open;
+        open = false;
+        if (wasOpen) {
+          currentConfig.onClose?.();
+        }
+      };
+
+      const update = (
+        options: Partial<{ onClose?: () => void; host?: string }>
+      ) => {
+        mockUpdate(options);
+        Object.assign(currentConfig, options);
+      };
+
+      sdkCloseRef.current = () => {
+        if (!open) return;
+        open = false;
+        currentConfig.onClose?.();
+      };
+
+      return {
+        unmount,
+        update,
+        destroy,
+        show,
+        hide,
+        get isOpen() {
+          return open;
+        },
+        researchId: config.researchId ?? "test-research-id",
+        type: "popup",
+        iframe: null,
+        container: null,
+      };
+    }
+  ),
 }));
 
 import { openPopup } from "@perspective-ai/sdk";
+
 const mockOpenPopup = vi.mocked(openPopup);
 
 describe("usePopup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sdkCloseRef.current = null;
     mockGetPersistedOpenState.mockReturnValue(null);
   });
 
@@ -36,7 +106,7 @@ describe("usePopup", () => {
     cleanup();
   });
 
-  it("returns open, close, toggle functions and isOpen state", () => {
+  it("returns open, close, toggle functions and initial state", () => {
     const { result } = renderHook(() =>
       usePopup({ researchId: "test-research-id" })
     );
@@ -45,47 +115,37 @@ describe("usePopup", () => {
     expect(result.current.close).toBeInstanceOf(Function);
     expect(result.current.toggle).toBeInstanceOf(Function);
     expect(result.current.isOpen).toBe(false);
-    expect(result.current.handle).toBeNull();
+    expect(result.current.handle).not.toBeNull();
   });
 
-  it("does not call openPopup on mount", () => {
+  it("preloads a hidden popup on mount", () => {
     renderHook(() => usePopup({ researchId: "test-research-id" }));
-
-    expect(mockOpenPopup).not.toHaveBeenCalled();
-  });
-
-  it("calls openPopup when open() is called", () => {
-    const { result } = renderHook(() =>
-      usePopup({ researchId: "test-research-id" })
-    );
-
-    act(() => {
-      result.current.open();
-    });
 
     expect(mockOpenPopup).toHaveBeenCalledTimes(1);
     expect(mockOpenPopup).toHaveBeenCalledWith(
       expect.objectContaining({
         researchId: "test-research-id",
+        _startHidden: true,
       })
     );
   });
 
-  it("sets isOpen to true when open() is called", () => {
+  it("opens the preloaded popup without recreating it", () => {
     const { result } = renderHook(() =>
       usePopup({ researchId: "test-research-id" })
     );
-
-    expect(result.current.isOpen).toBe(false);
 
     act(() => {
       result.current.open();
     });
 
+    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(1);
     expect(result.current.isOpen).toBe(true);
+    expect(result.current.handle).not.toBeNull();
   });
 
-  it("calls destroy and sets isOpen to false when close() is called", () => {
+  it("hides the popup on close but keeps the handle for instant reopen", () => {
     const { result } = renderHook(() =>
       usePopup({ researchId: "test-research-id" })
     );
@@ -93,23 +153,38 @@ describe("usePopup", () => {
     act(() => {
       result.current.open();
     });
-
-    expect(result.current.isOpen).toBe(true);
 
     act(() => {
       result.current.close();
     });
 
-    expect(mockDestroy).toHaveBeenCalledTimes(1);
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
     expect(result.current.isOpen).toBe(false);
+    expect(result.current.handle).not.toBeNull();
   });
 
-  it("toggles open state", () => {
+  it("reuses the same popup on reopen after close", () => {
     const { result } = renderHook(() =>
       usePopup({ researchId: "test-research-id" })
     );
 
-    expect(result.current.isOpen).toBe(false);
+    act(() => {
+      result.current.open();
+      result.current.close();
+      result.current.open();
+    });
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(2);
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("toggles open state using the same underlying popup", () => {
+    const { result } = renderHook(() =>
+      usePopup({ researchId: "test-research-id" })
+    );
 
     act(() => {
       result.current.toggle();
@@ -117,20 +192,22 @@ describe("usePopup", () => {
 
     expect(result.current.isOpen).toBe(true);
     expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.toggle();
     });
 
     expect(result.current.isOpen).toBe(false);
-    expect(mockDestroy).toHaveBeenCalledTimes(1);
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
   });
 
-  it("passes config to openPopup", () => {
+  it("passes config to openPopup during preload creation", () => {
     const onReady = vi.fn();
     const onSubmit = vi.fn();
 
-    const { result } = renderHook(() =>
+    renderHook(() =>
       usePopup({
         researchId: "test-research-id",
         params: { source: "test" },
@@ -141,16 +218,13 @@ describe("usePopup", () => {
       })
     );
 
-    act(() => {
-      result.current.open();
-    });
-
     expect(mockOpenPopup).toHaveBeenCalledTimes(1);
     const config = mockOpenPopup.mock.calls[0]![0];
     expect(config.researchId).toBe("test-research-id");
     expect(config.params).toEqual({ source: "test" });
     expect(config.theme).toBe("dark");
     expect(config.host).toBe("https://custom.example.com");
+    expect(config._startHidden).toBe(true);
   });
 
   it("passes disableClose to openPopup", () => {
@@ -169,10 +243,10 @@ describe("usePopup", () => {
     );
   });
 
-  it("supports controlled mode with open prop", () => {
+  it("supports controlled mode with open prop using show and hide", () => {
     const onOpenChange = vi.fn();
 
-    const { result, rerender } = renderHook(
+    const { rerender } = renderHook(
       ({ open }) =>
         usePopup({
           researchId: "test-research-id",
@@ -182,15 +256,15 @@ describe("usePopup", () => {
       { initialProps: { open: false } }
     );
 
-    expect(result.current.isOpen).toBe(false);
-
-    rerender({ open: true });
-
     expect(mockOpenPopup).toHaveBeenCalledTimes(1);
 
-    rerender({ open: false });
+    rerender({ open: true });
+    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(1);
 
-    expect(mockDestroy).toHaveBeenCalledTimes(1);
+    rerender({ open: false });
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
   });
 
   it("calls onOpenChange in controlled mode when open() is called", () => {
@@ -212,32 +286,148 @@ describe("usePopup", () => {
   });
 
   it("cleans up on unmount without treating it as explicit close", () => {
-    const { result, unmount } = renderHook(() =>
+    const { unmount } = renderHook(() =>
       usePopup({ researchId: "test-research-id" })
     );
 
-    act(() => {
-      result.current.open();
-    });
-
     unmount();
 
-    expect(mockUnmount).toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith({ onClose: undefined });
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
     expect(mockDestroy).not.toHaveBeenCalled();
   });
 
-  it("makes handle reactive - handle is available after open", () => {
+  it("keeps the handle available after mount", () => {
     const { result } = renderHook(() =>
       usePopup({ researchId: "test-research-id" })
     );
 
-    expect(result.current.handle).toBeNull();
+    expect(result.current.handle).not.toBeNull();
+  });
+
+  it("updates state when the SDK triggers onClose without destroying the popup", () => {
+    const onClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePopup({
+        researchId: "test-research-id",
+        onClose,
+      })
+    );
 
     act(() => {
       result.current.open();
     });
 
+    act(() => {
+      sdkCloseRef.current?.();
+    });
+
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(result.current.isOpen).toBe(false);
     expect(result.current.handle).not.toBeNull();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("recreates the popup when researchId changes", () => {
+    const { rerender } = renderHook(
+      ({ researchId }) =>
+        usePopup({
+          researchId,
+        }),
+      { initialProps: { researchId: "research-1" } }
+    );
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+
+    rerender({ researchId: "research-2" });
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+  });
+
+  it("recreates a hidden popup when iframe-defining config changes", () => {
+    const onClose = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ params }) =>
+        usePopup({
+          researchId: "test-research-id",
+          params,
+          onClose,
+        }),
+      { initialProps: { params: { source: "first" } } }
+    );
+
+    expect(result.current.isOpen).toBe(false);
+    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+
+    rerender({ params: { source: "second" } });
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(mockOpenPopup.mock.calls[1]?.[0]._startHidden).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("keeps controlled popup open when recreated while open", () => {
+    const onOpenChange = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ researchId }) =>
+        usePopup({
+          researchId,
+          open: true,
+          onOpenChange,
+        }),
+      { initialProps: { researchId: "research-1" } }
+    );
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+    expect(result.current.isOpen).toBe(true);
+
+    rerender({ researchId: "research-2" });
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(mockOpenPopup.mock.calls[1]?.[0]._startHidden).toBe(false);
+    expect(result.current.handle).not.toBeNull();
+    expect(result.current.isOpen).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps uncontrolled popup open when recreated while open", () => {
+    const onClose = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ params }) =>
+        usePopup({
+          researchId: "test-research-id",
+          params,
+          onClose,
+        }),
+      { initialProps: { params: { source: "first" } } }
+    );
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+    expect(result.current.isOpen).toBe(true);
+
+    rerender({ params: { source: "second" } });
+
+    expect(mockOpenPopup).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(mockOpenPopup.mock.calls[1]?.[0]._startHidden).toBe(false);
+    expect(result.current.handle).not.toBeNull();
+    expect(result.current.isOpen).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("restores persisted open state on mount in uncontrolled mode", () => {
@@ -248,6 +438,7 @@ describe("usePopup", () => {
     );
 
     expect(mockOpenPopup).toHaveBeenCalledTimes(1);
+    expect(mockOpenPopup.mock.calls[0]?.[0]._startHidden).toBe(false);
     expect(result.current.isOpen).toBe(true);
     expect(result.current.handle).not.toBeNull();
   });

--- a/packages/sdk-react/src/hooks/usePopup.ts
+++ b/packages/sdk-react/src/hooks/usePopup.ts
@@ -1,31 +1,16 @@
-import { useCallback, useState, useEffect, useRef } from "react";
+import { openPopup, type EmbedHandle } from "@perspective-ai/sdk";
 import {
-  getPersistedOpenState,
-  openPopup,
-  type EmbedConfig,
-  type EmbedHandle,
-} from "@perspective-ai/sdk";
-import { useStableCallback } from "./useStableCallback";
+  useToggleableEmbed,
+  type UseToggleableEmbedOptions,
+  type UseToggleableEmbedReturn,
+} from "./useToggleableEmbed";
 
 /** Options for usePopup hook */
-export interface UsePopupOptions extends Omit<EmbedConfig, "type"> {
-  /** Controlled open state */
-  open?: boolean;
-  /** Callback when open state changes */
-  onOpenChange?: (open: boolean) => void;
-}
+export interface UsePopupOptions extends UseToggleableEmbedOptions {}
 
 /** Return type for usePopup hook */
-export interface UsePopupReturn {
-  /** Open the popup */
-  open: () => void;
-  /** Close the popup */
-  close: () => void;
-  /** Toggle the popup */
-  toggle: () => void;
-  /** Whether the popup is currently open */
-  isOpen: boolean;
-  /** The underlying SDK handle (null when closed) */
+export interface UsePopupReturn extends UseToggleableEmbedReturn {
+  /** The underlying SDK handle (created on mount; may be null during initial render) */
   handle: EmbedHandle | null;
 }
 
@@ -49,161 +34,5 @@ export interface UsePopupReturn {
  * ```
  */
 export function usePopup(options: UsePopupOptions): UsePopupReturn {
-  const {
-    researchId,
-    params,
-    brand,
-    theme,
-    host,
-    disableClose,
-    onReady,
-    onSubmit,
-    onNavigate,
-    onClose,
-    onError,
-    open: controlledOpen,
-    onOpenChange,
-  } = options;
-
-  const [handle, setHandle] = useState<EmbedHandle | null>(null);
-  const [internalOpen, setInternalOpen] = useState(false);
-  const handleRef = useRef<EmbedHandle | null>(null);
-
-  const isControlled = controlledOpen !== undefined;
-  const isOpen = isControlled ? controlledOpen : internalOpen;
-
-  const stableOnReady = useStableCallback(onReady);
-  const stableOnSubmit = useStableCallback(onSubmit);
-  const stableOnNavigate = useStableCallback(onNavigate);
-  const stableOnError = useStableCallback(onError);
-
-  const setOpen = useCallback(
-    (value: boolean) => {
-      if (isControlled) {
-        onOpenChange?.(value);
-      } else {
-        setInternalOpen(value);
-      }
-    },
-    [isControlled, onOpenChange]
-  );
-
-  const handleClose = useCallback(() => {
-    handleRef.current = null;
-    setHandle(null);
-    setOpen(false);
-    onClose?.();
-  }, [setOpen, onClose]);
-
-  const stableOnClose = useStableCallback(handleClose);
-
-  const createPopup = useCallback(() => {
-    if (handleRef.current) return handleRef.current;
-
-    const newHandle = openPopup({
-      researchId,
-      params,
-      brand,
-      theme,
-      host,
-      disableClose,
-      onReady: stableOnReady,
-      onSubmit: stableOnSubmit,
-      onNavigate: stableOnNavigate,
-      onClose: stableOnClose,
-      onError: stableOnError,
-    });
-
-    handleRef.current = newHandle;
-    setHandle(newHandle);
-    return newHandle;
-  }, [
-    researchId,
-    params,
-    brand,
-    theme,
-    host,
-    disableClose,
-    stableOnReady,
-    stableOnSubmit,
-    stableOnNavigate,
-    stableOnClose,
-    stableOnError,
-  ]);
-
-  const destroyPopup = useCallback((mode: "destroy" | "unmount") => {
-    if (handleRef.current) {
-      if (mode === "destroy") {
-        handleRef.current.destroy();
-      } else {
-        handleRef.current.unmount();
-      }
-      handleRef.current = null;
-      setHandle(null);
-    }
-  }, []);
-
-  const openFn = useCallback(() => {
-    if (isControlled) {
-      onOpenChange?.(true);
-    } else {
-      createPopup();
-      setInternalOpen(true);
-    }
-  }, [isControlled, onOpenChange, createPopup]);
-
-  const closeFn = useCallback(() => {
-    if (isControlled) {
-      onOpenChange?.(false);
-    } else {
-      destroyPopup("destroy");
-      setInternalOpen(false);
-    }
-  }, [isControlled, onOpenChange, destroyPopup]);
-
-  const toggleFn = useCallback(() => {
-    if (isOpen) {
-      closeFn();
-    } else {
-      openFn();
-    }
-  }, [isOpen, openFn, closeFn]);
-
-  useEffect(() => {
-    if (!isControlled) return;
-
-    if (controlledOpen && !handleRef.current) {
-      createPopup();
-    } else if (!controlledOpen && handleRef.current) {
-      destroyPopup("destroy");
-    }
-  }, [controlledOpen, isControlled, createPopup, destroyPopup]);
-
-  useEffect(() => {
-    if (isControlled || handleRef.current) return;
-
-    if (getPersistedOpenState({ researchId, type: "popup", host }) !== true) {
-      return;
-    }
-
-    createPopup();
-    setInternalOpen(true);
-  }, [createPopup, host, isControlled, researchId]);
-
-  useEffect(() => {
-    return () => {
-      if (handleRef.current) {
-        handleRef.current.unmount();
-        handleRef.current = null;
-      }
-    };
-  }, []);
-
-  return {
-    open: openFn,
-    close: closeFn,
-    toggle: toggleFn,
-    isOpen,
-    handle,
-  };
+  return useToggleableEmbed(options, openPopup, "popup");
 }

--- a/packages/sdk-react/src/hooks/useSlider.test.ts
+++ b/packages/sdk-react/src/hooks/useSlider.test.ts
@@ -2,33 +2,103 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, cleanup } from "@testing-library/react";
 import { useSlider } from "./useSlider";
 
-const { mockDestroy, mockUnmount, mockUpdate, mockGetPersistedOpenState } =
-  vi.hoisted(() => ({
-    mockDestroy: vi.fn(),
-    mockUnmount: vi.fn(),
-    mockUpdate: vi.fn(),
-    mockGetPersistedOpenState: vi.fn(),
-  }));
+const {
+  mockDestroy,
+  mockUnmount,
+  mockUpdate,
+  mockShow,
+  mockHide,
+  mockGetPersistedOpenState,
+  sdkCloseRef,
+} = vi.hoisted(() => ({
+  mockDestroy: vi.fn(),
+  mockUnmount: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockShow: vi.fn(),
+  mockHide: vi.fn(),
+  mockGetPersistedOpenState: vi.fn(),
+  sdkCloseRef: { current: null as (() => void) | null },
+}));
 
 vi.mock("@perspective-ai/sdk", () => ({
   getPersistedOpenState: mockGetPersistedOpenState,
-  openSlider: vi.fn(() => ({
-    unmount: mockUnmount,
-    update: mockUpdate,
-    destroy: mockDestroy,
-    researchId: "test-research-id",
-    type: "slider",
-    iframe: null,
-    container: null,
-  })),
+  stableSerialize: vi.fn((value: unknown) => JSON.stringify(value)),
+  openSlider: vi.fn(
+    (config: {
+      researchId?: string;
+      onClose?: () => void;
+      host?: string;
+      _startHidden?: boolean;
+    }) => {
+      const currentConfig = { ...config };
+      let open = !config._startHidden;
+
+      const show = () => {
+        if (open) return;
+        mockShow();
+        open = true;
+      };
+
+      const hide = () => {
+        if (!open) return;
+        mockHide();
+        open = false;
+        currentConfig.onClose?.();
+      };
+
+      const unmount = () => {
+        mockUnmount();
+        open = false;
+      };
+
+      const destroy = () => {
+        mockDestroy();
+        const wasOpen = open;
+        open = false;
+        if (wasOpen) {
+          currentConfig.onClose?.();
+        }
+      };
+
+      const update = (
+        options: Partial<{ onClose?: () => void; host?: string }>
+      ) => {
+        mockUpdate(options);
+        Object.assign(currentConfig, options);
+      };
+
+      sdkCloseRef.current = () => {
+        if (!open) return;
+        open = false;
+        currentConfig.onClose?.();
+      };
+
+      return {
+        unmount,
+        update,
+        destroy,
+        show,
+        hide,
+        get isOpen() {
+          return open;
+        },
+        researchId: config.researchId ?? "test-research-id",
+        type: "slider",
+        iframe: null,
+        container: null,
+      };
+    }
+  ),
 }));
 
 import { openSlider } from "@perspective-ai/sdk";
+
 const mockOpenSlider = vi.mocked(openSlider);
 
 describe("useSlider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sdkCloseRef.current = null;
     mockGetPersistedOpenState.mockReturnValue(null);
   });
 
@@ -36,7 +106,7 @@ describe("useSlider", () => {
     cleanup();
   });
 
-  it("returns open, close, toggle functions and isOpen state", () => {
+  it("returns open, close, toggle functions and initial state", () => {
     const { result } = renderHook(() =>
       useSlider({ researchId: "test-research-id" })
     );
@@ -45,47 +115,37 @@ describe("useSlider", () => {
     expect(result.current.close).toBeInstanceOf(Function);
     expect(result.current.toggle).toBeInstanceOf(Function);
     expect(result.current.isOpen).toBe(false);
-    expect(result.current.handle).toBeNull();
+    expect(result.current.handle).not.toBeNull();
   });
 
-  it("does not call openSlider on mount", () => {
+  it("preloads a hidden slider on mount", () => {
     renderHook(() => useSlider({ researchId: "test-research-id" }));
-
-    expect(mockOpenSlider).not.toHaveBeenCalled();
-  });
-
-  it("calls openSlider when open() is called", () => {
-    const { result } = renderHook(() =>
-      useSlider({ researchId: "test-research-id" })
-    );
-
-    act(() => {
-      result.current.open();
-    });
 
     expect(mockOpenSlider).toHaveBeenCalledTimes(1);
     expect(mockOpenSlider).toHaveBeenCalledWith(
       expect.objectContaining({
         researchId: "test-research-id",
+        _startHidden: true,
       })
     );
   });
 
-  it("sets isOpen to true when open() is called", () => {
+  it("opens the preloaded slider without recreating it", () => {
     const { result } = renderHook(() =>
       useSlider({ researchId: "test-research-id" })
     );
-
-    expect(result.current.isOpen).toBe(false);
 
     act(() => {
       result.current.open();
     });
 
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(1);
     expect(result.current.isOpen).toBe(true);
+    expect(result.current.handle).not.toBeNull();
   });
 
-  it("calls destroy and sets isOpen to false when close() is called", () => {
+  it("hides the slider on close but keeps the handle for instant reopen", () => {
     const { result } = renderHook(() =>
       useSlider({ researchId: "test-research-id" })
     );
@@ -93,23 +153,38 @@ describe("useSlider", () => {
     act(() => {
       result.current.open();
     });
-
-    expect(result.current.isOpen).toBe(true);
 
     act(() => {
       result.current.close();
     });
 
-    expect(mockDestroy).toHaveBeenCalledTimes(1);
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
     expect(result.current.isOpen).toBe(false);
+    expect(result.current.handle).not.toBeNull();
   });
 
-  it("toggles open state", () => {
+  it("reuses the same slider on reopen after close", () => {
     const { result } = renderHook(() =>
       useSlider({ researchId: "test-research-id" })
     );
 
-    expect(result.current.isOpen).toBe(false);
+    act(() => {
+      result.current.open();
+      result.current.close();
+      result.current.open();
+    });
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(2);
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("toggles open state using the same underlying slider", () => {
+    const { result } = renderHook(() =>
+      useSlider({ researchId: "test-research-id" })
+    );
 
     act(() => {
       result.current.toggle();
@@ -117,13 +192,15 @@ describe("useSlider", () => {
 
     expect(result.current.isOpen).toBe(true);
     expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.toggle();
     });
 
     expect(result.current.isOpen).toBe(false);
-    expect(mockDestroy).toHaveBeenCalledTimes(1);
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
   });
 
   it("passes disableClose to openSlider", () => {
@@ -142,33 +219,210 @@ describe("useSlider", () => {
     );
   });
 
-  it("cleans up on unmount without treating it as explicit close", () => {
-    const { result, unmount } = renderHook(() =>
-      useSlider({ researchId: "test-research-id" })
+  it("passes config to openSlider during preload creation", () => {
+    renderHook(() =>
+      useSlider({
+        researchId: "test-research-id",
+        params: { source: "test" },
+        theme: "dark",
+        host: "https://custom.example.com",
+      })
+    );
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    const config = mockOpenSlider.mock.calls[0]![0];
+    expect(config.researchId).toBe("test-research-id");
+    expect(config.params).toEqual({ source: "test" });
+    expect(config.theme).toBe("dark");
+    expect(config.host).toBe("https://custom.example.com");
+    expect(config._startHidden).toBe(true);
+  });
+
+  it("supports controlled mode with open prop using show and hide", () => {
+    const onOpenChange = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ open }) =>
+        useSlider({
+          researchId: "test-research-id",
+          open,
+          onOpenChange,
+        }),
+      { initialProps: { open: false } }
+    );
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+
+    rerender({ open: true });
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    expect(mockShow).toHaveBeenCalledTimes(1);
+
+    rerender({ open: false });
+    expect(mockHide).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+  });
+
+  it("calls onOpenChange in controlled mode when open() is called", () => {
+    const onOpenChange = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSlider({
+        researchId: "test-research-id",
+        open: false,
+        onOpenChange,
+      })
     );
 
     act(() => {
       result.current.open();
     });
 
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("cleans up on unmount without treating it as explicit close", () => {
+    const { unmount } = renderHook(() =>
+      useSlider({ researchId: "test-research-id" })
+    );
+
     unmount();
 
-    expect(mockUnmount).toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith({ onClose: undefined });
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
     expect(mockDestroy).not.toHaveBeenCalled();
   });
 
-  it("makes handle reactive - handle is available after open", () => {
+  it("keeps the handle available after mount", () => {
     const { result } = renderHook(() =>
       useSlider({ researchId: "test-research-id" })
     );
 
-    expect(result.current.handle).toBeNull();
+    expect(result.current.handle).not.toBeNull();
+  });
+
+  it("updates state when the SDK triggers onClose without destroying the slider", () => {
+    const onClose = vi.fn();
+    const { result } = renderHook(() =>
+      useSlider({
+        researchId: "test-research-id",
+        onClose,
+      })
+    );
 
     act(() => {
       result.current.open();
     });
 
+    act(() => {
+      sdkCloseRef.current?.();
+    });
+
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(result.current.isOpen).toBe(false);
     expect(result.current.handle).not.toBeNull();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("recreates the slider when researchId changes", () => {
+    const { rerender } = renderHook(
+      ({ researchId }) =>
+        useSlider({
+          researchId,
+        }),
+      { initialProps: { researchId: "research-1" } }
+    );
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+
+    rerender({ researchId: "research-2" });
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+  });
+
+  it("recreates a hidden slider when iframe-defining config changes", () => {
+    const onClose = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ params }) =>
+        useSlider({
+          researchId: "test-research-id",
+          params,
+          onClose,
+        }),
+      { initialProps: { params: { source: "first" } } }
+    );
+
+    expect(result.current.isOpen).toBe(false);
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+
+    rerender({ params: { source: "second" } });
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(mockOpenSlider.mock.calls[1]?.[0]._startHidden).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("keeps controlled slider open when recreated while open", () => {
+    const onOpenChange = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ researchId }) =>
+        useSlider({
+          researchId,
+          open: true,
+          onOpenChange,
+        }),
+      { initialProps: { researchId: "research-1" } }
+    );
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    expect(result.current.isOpen).toBe(true);
+
+    rerender({ researchId: "research-2" });
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(mockOpenSlider.mock.calls[1]?.[0]._startHidden).toBe(false);
+    expect(result.current.handle).not.toBeNull();
+    expect(result.current.isOpen).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps uncontrolled slider open when recreated while open", () => {
+    const onClose = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ params }) =>
+        useSlider({
+          researchId: "test-research-id",
+          params,
+          onClose,
+        }),
+      { initialProps: { params: { source: "first" } } }
+    );
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    expect(result.current.isOpen).toBe(true);
+
+    rerender({ params: { source: "second" } });
+
+    expect(mockOpenSlider).toHaveBeenCalledTimes(2);
+    expect(mockUnmount).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).not.toHaveBeenCalled();
+    expect(mockOpenSlider.mock.calls[1]?.[0]._startHidden).toBe(false);
+    expect(result.current.handle).not.toBeNull();
+    expect(result.current.isOpen).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("restores persisted open state on mount in uncontrolled mode", () => {
@@ -179,6 +433,7 @@ describe("useSlider", () => {
     );
 
     expect(mockOpenSlider).toHaveBeenCalledTimes(1);
+    expect(mockOpenSlider.mock.calls[0]?.[0]._startHidden).toBe(false);
     expect(result.current.isOpen).toBe(true);
     expect(result.current.handle).not.toBeNull();
   });

--- a/packages/sdk-react/src/hooks/useSlider.ts
+++ b/packages/sdk-react/src/hooks/useSlider.ts
@@ -1,31 +1,16 @@
-import { useCallback, useState, useEffect, useRef } from "react";
+import { openSlider, type EmbedHandle } from "@perspective-ai/sdk";
 import {
-  getPersistedOpenState,
-  openSlider,
-  type EmbedConfig,
-  type EmbedHandle,
-} from "@perspective-ai/sdk";
-import { useStableCallback } from "./useStableCallback";
+  useToggleableEmbed,
+  type UseToggleableEmbedOptions,
+  type UseToggleableEmbedReturn,
+} from "./useToggleableEmbed";
 
 /** Options for useSlider hook */
-export interface UseSliderOptions extends Omit<EmbedConfig, "type"> {
-  /** Controlled open state */
-  open?: boolean;
-  /** Callback when open state changes */
-  onOpenChange?: (open: boolean) => void;
-}
+export interface UseSliderOptions extends UseToggleableEmbedOptions {}
 
 /** Return type for useSlider hook */
-export interface UseSliderReturn {
-  /** Open the slider */
-  open: () => void;
-  /** Close the slider */
-  close: () => void;
-  /** Toggle the slider */
-  toggle: () => void;
-  /** Whether the slider is currently open */
-  isOpen: boolean;
-  /** The underlying SDK handle (null when closed) */
+export interface UseSliderReturn extends UseToggleableEmbedReturn {
+  /** The underlying SDK handle (created on mount; may be null during initial render) */
   handle: EmbedHandle | null;
 }
 
@@ -40,161 +25,5 @@ export interface UseSliderReturn {
  * ```
  */
 export function useSlider(options: UseSliderOptions): UseSliderReturn {
-  const {
-    researchId,
-    params,
-    brand,
-    theme,
-    host,
-    disableClose,
-    onReady,
-    onSubmit,
-    onNavigate,
-    onClose,
-    onError,
-    open: controlledOpen,
-    onOpenChange,
-  } = options;
-
-  const [handle, setHandle] = useState<EmbedHandle | null>(null);
-  const [internalOpen, setInternalOpen] = useState(false);
-  const handleRef = useRef<EmbedHandle | null>(null);
-
-  const isControlled = controlledOpen !== undefined;
-  const isOpen = isControlled ? controlledOpen : internalOpen;
-
-  const stableOnReady = useStableCallback(onReady);
-  const stableOnSubmit = useStableCallback(onSubmit);
-  const stableOnNavigate = useStableCallback(onNavigate);
-  const stableOnError = useStableCallback(onError);
-
-  const setOpen = useCallback(
-    (value: boolean) => {
-      if (isControlled) {
-        onOpenChange?.(value);
-      } else {
-        setInternalOpen(value);
-      }
-    },
-    [isControlled, onOpenChange]
-  );
-
-  const handleClose = useCallback(() => {
-    handleRef.current = null;
-    setHandle(null);
-    setOpen(false);
-    onClose?.();
-  }, [setOpen, onClose]);
-
-  const stableOnClose = useStableCallback(handleClose);
-
-  const createSlider = useCallback(() => {
-    if (handleRef.current) return handleRef.current;
-
-    const newHandle = openSlider({
-      researchId,
-      params,
-      brand,
-      theme,
-      host,
-      disableClose,
-      onReady: stableOnReady,
-      onSubmit: stableOnSubmit,
-      onNavigate: stableOnNavigate,
-      onClose: stableOnClose,
-      onError: stableOnError,
-    });
-
-    handleRef.current = newHandle;
-    setHandle(newHandle);
-    return newHandle;
-  }, [
-    researchId,
-    params,
-    brand,
-    theme,
-    host,
-    disableClose,
-    stableOnReady,
-    stableOnSubmit,
-    stableOnNavigate,
-    stableOnClose,
-    stableOnError,
-  ]);
-
-  const destroySlider = useCallback((mode: "destroy" | "unmount") => {
-    if (handleRef.current) {
-      if (mode === "destroy") {
-        handleRef.current.destroy();
-      } else {
-        handleRef.current.unmount();
-      }
-      handleRef.current = null;
-      setHandle(null);
-    }
-  }, []);
-
-  const openFn = useCallback(() => {
-    if (isControlled) {
-      onOpenChange?.(true);
-    } else {
-      createSlider();
-      setInternalOpen(true);
-    }
-  }, [isControlled, onOpenChange, createSlider]);
-
-  const closeFn = useCallback(() => {
-    if (isControlled) {
-      onOpenChange?.(false);
-    } else {
-      destroySlider("destroy");
-      setInternalOpen(false);
-    }
-  }, [isControlled, onOpenChange, destroySlider]);
-
-  const toggleFn = useCallback(() => {
-    if (isOpen) {
-      closeFn();
-    } else {
-      openFn();
-    }
-  }, [isOpen, openFn, closeFn]);
-
-  useEffect(() => {
-    if (!isControlled) return;
-
-    if (controlledOpen && !handleRef.current) {
-      createSlider();
-    } else if (!controlledOpen && handleRef.current) {
-      destroySlider("destroy");
-    }
-  }, [controlledOpen, isControlled, createSlider, destroySlider]);
-
-  useEffect(() => {
-    if (isControlled || handleRef.current) return;
-
-    if (getPersistedOpenState({ researchId, type: "slider", host }) !== true) {
-      return;
-    }
-
-    createSlider();
-    setInternalOpen(true);
-  }, [createSlider, host, isControlled, researchId]);
-
-  useEffect(() => {
-    return () => {
-      if (handleRef.current) {
-        handleRef.current.unmount();
-        handleRef.current = null;
-      }
-    };
-  }, []);
-
-  return {
-    open: openFn,
-    close: closeFn,
-    toggle: toggleFn,
-    isOpen,
-    handle,
-  };
+  return useToggleableEmbed(options, openSlider, "slider");
 }

--- a/packages/sdk-react/src/hooks/useStableCallback.ts
+++ b/packages/sdk-react/src/hooks/useStableCallback.ts
@@ -3,10 +3,19 @@ import { useRef, useCallback, useLayoutEffect, useEffect } from "react";
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
-export function useStableCallback<
-  T extends ((...args: any[]) => any) | undefined,
->(callback: T): T {
-  const callbackRef = useRef(callback);
+type Callback<TArgs extends unknown[], TResult> = (...args: TArgs) => TResult;
+
+export function useStableCallback<TArgs extends unknown[], TResult>(
+  callback: Callback<TArgs, TResult>
+): Callback<TArgs, TResult>;
+export function useStableCallback(callback: undefined): undefined;
+export function useStableCallback<TArgs extends unknown[], TResult>(
+  callback: Callback<TArgs, TResult> | undefined
+): Callback<TArgs, TResult> | undefined;
+export function useStableCallback<TArgs extends unknown[], TResult>(
+  callback: Callback<TArgs, TResult> | undefined
+): Callback<TArgs, TResult> | undefined {
+  const callbackRef = useRef<Callback<TArgs, TResult> | undefined>(callback);
 
   useIsomorphicLayoutEffect(() => {
     callbackRef.current = callback;
@@ -15,10 +24,9 @@ export function useStableCallback<
   // Always create the stable wrapper (hooks can't be conditional),
   // but return undefined when no callback is provided to preserve
   // truthiness semantics for consumers that branch on it.
-  const stable = useCallback(
-    ((...args: any[]) => callbackRef.current?.(...args)) as NonNullable<T>,
-    []
-  );
+  const stable = useCallback((...args: TArgs) => {
+    return callbackRef.current?.(...args);
+  }, []);
 
-  return callback ? stable : callback;
+  return callback ? (stable as Callback<TArgs, TResult>) : undefined;
 }

--- a/packages/sdk-react/src/hooks/useStableValue.test.ts
+++ b/packages/sdk-react/src/hooks/useStableValue.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+vi.mock("@perspective-ai/sdk", () => ({
+  stableSerialize: (value: unknown) =>
+    JSON.stringify(value, (_key, currentValue) => {
+      if (
+        currentValue !== null &&
+        typeof currentValue === "object" &&
+        !Array.isArray(currentValue)
+      ) {
+        return Object.keys(currentValue as Record<string, unknown>)
+          .sort()
+          .reduce<Record<string, unknown>>((result, key) => {
+            result[key] = (currentValue as Record<string, unknown>)[key];
+            return result;
+          }, {});
+      }
+
+      return currentValue;
+    }),
+}));
+
+import { useStableValue } from "./useStableValue";
+
+describe("useStableValue", () => {
+  it("returns the same reference for deeply equal objects", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value),
+      { initialProps: { value: { a: 1, b: "test" } } }
+    );
+
+    const first = result.current;
+
+    rerender({ value: { a: 1, b: "test" } });
+
+    expect(result.current).toBe(first);
+  });
+
+  it("returns new reference when value changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value),
+      { initialProps: { value: { a: 1 } } }
+    );
+
+    const first = result.current;
+
+    rerender({ value: { a: 2 } });
+
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual({ a: 2 });
+  });
+
+  it("ignores object key order differences", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value),
+      {
+        initialProps: {
+          value: {
+            dark: { secondary: "#222", primary: "#111" },
+            light: { secondary: "#eee", primary: "#fff" },
+          },
+        },
+      }
+    );
+
+    const first = result.current;
+
+    rerender({
+      value: {
+        light: { primary: "#fff", secondary: "#eee" },
+        dark: { primary: "#111", secondary: "#222" },
+      },
+    });
+
+    expect(result.current).toBe(first);
+  });
+
+  it("handles undefined values", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value),
+      {
+        initialProps: {
+          value: undefined as Record<string, unknown> | undefined,
+        },
+      }
+    );
+
+    expect(result.current).toBeUndefined();
+
+    rerender({ value: undefined });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("handles primitive values", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value),
+      { initialProps: { value: "hello" } }
+    );
+
+    const first = result.current;
+
+    rerender({ value: "hello" });
+    expect(result.current).toBe(first);
+
+    rerender({ value: "world" });
+    expect(result.current).toBe("world");
+  });
+
+  it("handles arrays with nested objects", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useStableValue(value),
+      {
+        initialProps: {
+          value: [{ b: 2, a: 1 }, { items: ["x", "y"] }],
+        },
+      }
+    );
+
+    const first = result.current;
+
+    rerender({
+      value: [{ a: 1, b: 2 }, { items: ["x", "y"] }],
+    });
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/packages/sdk-react/src/hooks/useStableValue.ts
+++ b/packages/sdk-react/src/hooks/useStableValue.ts
@@ -1,0 +1,20 @@
+import { stableSerialize } from "@perspective-ai/sdk";
+import { useRef } from "react";
+
+/**
+ * Returns a referentially stable version of a value.
+ * Uses JSON serialization to detect deep equality changes.
+ * Useful for object/array deps in useEffect that are recreated each render.
+ */
+export function useStableValue<T>(value: T): T {
+  const ref = useRef(value);
+  const serialized = stableSerialize(value);
+  const prevSerialized = useRef(serialized);
+
+  if (prevSerialized.current !== serialized) {
+    prevSerialized.current = serialized;
+    ref.current = value;
+  }
+
+  return ref.current;
+}

--- a/packages/sdk-react/src/hooks/useToggleableEmbed.ts
+++ b/packages/sdk-react/src/hooks/useToggleableEmbed.ts
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getPersistedOpenState,
+  type EmbedConfig,
+  type EmbedHandle,
+} from "@perspective-ai/sdk";
+import { useStableCallback } from "./useStableCallback";
+import { useStableValue } from "./useStableValue";
+
+type ToggleableConfig = Parameters<
+  typeof import("@perspective-ai/sdk").openPopup
+>[0];
+
+type ToggleableSdkHandle = ReturnType<
+  typeof import("@perspective-ai/sdk").openPopup
+>;
+
+type CreateToggleableHandle = (config: ToggleableConfig) => ToggleableSdkHandle;
+
+export interface UseToggleableEmbedOptions extends Omit<EmbedConfig, "type"> {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export interface UseToggleableEmbedReturn {
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  isOpen: boolean;
+  handle: EmbedHandle | null;
+}
+
+export function useToggleableEmbed(
+  options: UseToggleableEmbedOptions,
+  createHandle: CreateToggleableHandle,
+  type: "popup" | "slider"
+): UseToggleableEmbedReturn {
+  const {
+    researchId,
+    params,
+    brand,
+    theme,
+    host,
+    disableClose,
+    onReady,
+    onSubmit,
+    onNavigate,
+    onClose,
+    onError,
+    onAuth,
+    channel,
+    welcomeMessage,
+    open: controlledOpen,
+    onOpenChange,
+  } = options;
+
+  const isControlled = controlledOpen !== undefined;
+  const [handle, setHandle] = useState<EmbedHandle | null>(null);
+  const [internalOpen, setInternalOpen] = useState(
+    () =>
+      !isControlled &&
+      getPersistedOpenState({ researchId, type, host }) === true
+  );
+  const handleRef = useRef<ToggleableSdkHandle | null>(null);
+
+  const isOpen = isControlled ? controlledOpen : internalOpen;
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
+
+  // Recompute persisted open state when the persistence key changes
+  const persistenceKey = `${researchId}:${type}:${host ?? ""}`;
+  const prevKeyRef = useRef(persistenceKey);
+  if (prevKeyRef.current !== persistenceKey) {
+    prevKeyRef.current = persistenceKey;
+    if (!isControlled) {
+      const persisted =
+        getPersistedOpenState({ researchId, type, host }) === true;
+      setInternalOpen(persisted);
+    }
+  }
+
+  const stableParams = useStableValue(params);
+  const stableBrand = useStableValue(brand);
+
+  const stableOnReady = useStableCallback(onReady);
+  const stableOnSubmit = useStableCallback(onSubmit);
+  const stableOnNavigate = useStableCallback(onNavigate);
+  const stableOnError = useStableCallback(onError);
+  const stableOnAuth = useStableCallback(onAuth);
+
+  const setOpen = useCallback(
+    (value: boolean) => {
+      if (isControlled) {
+        onOpenChange?.(value);
+      } else {
+        setInternalOpen(value);
+      }
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const teardownHandle = useCallback(
+    (targetHandle: ToggleableSdkHandle | null = handleRef.current) => {
+      if (!targetHandle) return;
+
+      targetHandle.update({ onClose: undefined });
+      targetHandle.unmount();
+
+      if (handleRef.current === targetHandle) {
+        handleRef.current = null;
+        setHandle(null);
+      }
+    },
+    []
+  );
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    onClose?.();
+  }, [setOpen, onClose]);
+
+  const stableOnClose = useStableCallback(handleClose);
+
+  const createEmbedHandle = useCallback(
+    (startHidden: boolean) =>
+      createHandle({
+        researchId,
+        params: stableParams,
+        brand: stableBrand,
+        theme,
+        host,
+        disableClose,
+        onReady: stableOnReady,
+        onSubmit: stableOnSubmit,
+        onNavigate: stableOnNavigate,
+        onClose: stableOnClose,
+        onError: stableOnError,
+        onAuth: stableOnAuth,
+        channel,
+        welcomeMessage,
+        _startHidden: startHidden,
+      }),
+    [
+      channel,
+      createHandle,
+      disableClose,
+      host,
+      researchId,
+      stableBrand,
+      stableOnAuth,
+      stableOnClose,
+      stableOnError,
+      stableOnNavigate,
+      stableOnReady,
+      stableOnSubmit,
+      stableParams,
+      theme,
+      welcomeMessage,
+    ]
+  );
+
+  const setEmbedHandle = useCallback(
+    (startHidden: boolean) => {
+      const newHandle = createEmbedHandle(startHidden);
+      handleRef.current = newHandle;
+      setHandle(newHandle);
+      return newHandle;
+    },
+    [createEmbedHandle]
+  );
+
+  useEffect(() => {
+    const currentHandle = handleRef.current;
+    if (!currentHandle) return;
+
+    if (isOpen) {
+      currentHandle.show();
+    } else {
+      currentHandle.hide();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    // Stable callback/value wrappers are part of this hook's contract.
+    // When any iframe-defining input changes, recreate the underlying embed.
+    const nextHandle = setEmbedHandle(!isOpenRef.current);
+
+    return () => {
+      if (handleRef.current === nextHandle) {
+        teardownHandle(nextHandle);
+      }
+    };
+  }, [setEmbedHandle, teardownHandle]);
+
+  const ensureHandle = useCallback(() => {
+    if (handleRef.current) return handleRef.current;
+
+    return setEmbedHandle(false);
+  }, [setEmbedHandle]);
+
+  const open = useCallback(() => {
+    if (isControlled) {
+      onOpenChange?.(true);
+    } else {
+      ensureHandle().show();
+      setInternalOpen(true);
+    }
+  }, [ensureHandle, isControlled, onOpenChange]);
+
+  const close = useCallback(() => {
+    if (isControlled) {
+      onOpenChange?.(false);
+    } else {
+      handleRef.current?.hide();
+      setInternalOpen(false);
+    }
+  }, [isControlled, onOpenChange]);
+
+  const toggle = useCallback(() => {
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  }, [close, isOpen, open]);
+
+  return {
+    open,
+    close,
+    toggle,
+    isOpen,
+    handle,
+  };
+}

--- a/packages/sdk-react/vitest.config.ts
+++ b/packages/sdk-react/vitest.config.ts
@@ -1,6 +1,14 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@perspective-ai/sdk": fileURLToPath(
+        new URL("../sdk/src/index.ts", import.meta.url)
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: "happy-dom",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -111,7 +111,6 @@ interface EmbedConfig {
   theme?: "light" | "dark" | "system"; // Theme preference (default: "system")
   channel?: "TEXT" | "VOICE" | ["TEXT", "VOICE"]; // Interaction mode (default: from server config)
   welcomeMessage?: string; // Teaser text next to float button (float-type only)
-  buttonText?: string; // Custom text for popup/slider trigger buttons
   params?: Record<string, string>; // Custom URL parameters for tracking
   brand?: {
     light?: BrandColors; // Light mode brand colors

--- a/packages/sdk/e2e/embed.spec.ts
+++ b/packages/sdk/e2e/embed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Route } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -19,6 +19,32 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // Path to built SDK - tests require build first
 const SDK_PATH = path.resolve(__dirname, "../dist/cdn/perspective.global.js");
 const MOCK_IFRAME_PATH = path.resolve(__dirname, "fixtures/mock-iframe.html");
+
+type TestEvent = {
+  name: string;
+  data?: unknown;
+  timestamp: number;
+};
+
+declare global {
+  interface Window {
+    __testEvents?: TestEvent[];
+    Perspective?: {
+      destroyAll: () => void;
+      autoInit: () => void;
+    };
+  }
+}
+
+async function getTestEvents(page: Page): Promise<TestEvent[]> {
+  return page.evaluate(() => window.__testEvents ?? []);
+}
+
+async function clearTestEvents(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__testEvents = [];
+  });
+}
 
 // Check SDK exists before running tests
 test.beforeAll(async () => {
@@ -134,7 +160,13 @@ test.describe("Script Tag Auto-Init", () => {
 
     // Float bubble is appended to body, not inside the container
     const floatBubble = page.locator("body > .perspective-float-bubble");
+    const floatWindow = page.locator("body > .perspective-float-window");
     await expect(floatBubble).toBeVisible();
+    await expect(floatWindow).toBeAttached();
+    await expect(floatWindow).not.toBeVisible();
+    await expect(
+      floatWindow.locator("iframe[data-perspective]")
+    ).toBeAttached();
   });
 
   test("restores popup open state after reload", async ({ page }) => {
@@ -365,8 +397,8 @@ test.describe("Popup Lifecycle", () => {
     await page.keyboard.press("Escape");
 
     // Check callback was fired
-    const events = await page.evaluate(() => (window as any).__testEvents);
-    expect(events.some((e: any) => e.name === "popup:close")).toBe(true);
+    const events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "popup:close")).toBe(true);
   });
 });
 
@@ -424,8 +456,8 @@ test.describe("Slider Lifecycle", () => {
     await page.keyboard.press("Escape");
 
     // Check callback was fired
-    const events = await page.evaluate(() => (window as any).__testEvents);
-    expect(events.some((e: any) => e.name === "slider:close")).toBe(true);
+    const events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "slider:close")).toBe(true);
   });
 });
 
@@ -440,8 +472,8 @@ test.describe("PostMessage Communication", () => {
     await page.waitForTimeout(200);
 
     // Check callback was fired
-    const events = await page.evaluate(() => (window as any).__testEvents);
-    expect(events.some((e: any) => e.name === "widget:ready")).toBe(true);
+    const events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "widget:ready")).toBe(true);
   });
 
   test("fires onSubmit when iframe sends submit message", async ({ page }) => {
@@ -463,8 +495,8 @@ test.describe("PostMessage Communication", () => {
     await page.waitForTimeout(100);
 
     // Check callback was fired
-    const events = await page.evaluate(() => (window as any).__testEvents);
-    expect(events.some((e: any) => e.name === "widget:submit")).toBe(true);
+    const events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "widget:submit")).toBe(true);
   });
 
   test("fires onError when iframe sends error message", async ({ page }) => {
@@ -486,8 +518,8 @@ test.describe("PostMessage Communication", () => {
     await page.waitForTimeout(100);
 
     // Check callback was fired
-    const events = await page.evaluate(() => (window as any).__testEvents);
-    const errorEvent = events.find((e: any) => e.name === "widget:error");
+    const events = await getTestEvents(page);
+    const errorEvent = events.find((event) => event.name === "widget:error");
     expect(errorEvent).toBeTruthy();
   });
 });
@@ -501,9 +533,7 @@ test.describe("Security", () => {
     await page.waitForTimeout(200);
 
     // Clear events
-    await page.evaluate(() => {
-      (window as any).__testEvents = [];
-    });
+    await clearTestEvents(page);
 
     // Send fake message from page context (wrong origin - not from iframe)
     await page.evaluate(() => {
@@ -519,8 +549,8 @@ test.describe("Security", () => {
     await page.waitForTimeout(100);
 
     // onSubmit should NOT have been called (message from wrong source)
-    const events = await page.evaluate(() => (window as any).__testEvents);
-    expect(events.some((e: any) => e.name === "widget:submit")).toBe(false);
+    const events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "widget:submit")).toBe(false);
   });
 
   test("iframe has correct sandbox attributes", async ({ page }) => {
@@ -612,7 +642,7 @@ test.describe("Auto-Trigger Popup", () => {
     await expect(overlay).toBeVisible();
 
     const iframe = page.locator(".perspective-modal iframe[data-perspective]");
-    await expect(iframe).toBeVisible();
+    await expect(iframe).toBeAttached();
 
     const src = await iframe.getAttribute("src");
     expect(src).toContain("pbbvdh26");
@@ -748,6 +778,284 @@ test.describe("Auto-Trigger Popup", () => {
   });
 });
 
+test.describe("Preload & Reuse Lifecycle", () => {
+  test("autoInit preloads hidden iframe for button popup trigger", async ({
+    page,
+  }) => {
+    await page.goto("/preload-reuse.html");
+
+    // Wait for requestIdleCallback to fire and iframe to load
+    await page.waitForTimeout(500);
+
+    // A hidden preloaded iframe should exist in the DOM
+    const preloadIframe = page.locator(
+      "iframe[data-perspective-preload='test-popup']"
+    );
+    await expect(preloadIframe).toBeAttached();
+
+    // It should be visually hidden (opacity: 0, not display: none)
+    const opacity = await preloadIframe.evaluate(
+      (el) => (el as HTMLElement).style.opacity
+    );
+    expect(opacity).toBe("0");
+  });
+
+  test("preloaded popup opens without loading indicator and fires onReady", async ({
+    page,
+  }) => {
+    await page.goto("/preload-reuse.html");
+
+    // Wait for preload to complete (requestIdleCallback + iframe load + ready)
+    await page.waitForTimeout(500);
+
+    // Verify preloaded iframe exists
+    await expect(
+      page.locator("iframe[data-perspective-preload='test-popup']")
+    ).toBeAttached();
+
+    // Open popup via programmatic init (with onReady callback)
+    await page.click("#init-popup-btn");
+
+    // Popup should be visible
+    await expect(page.locator(".perspective-overlay")).toBeVisible();
+
+    // Preload attribute should be removed (iframe was claimed)
+    await expect(
+      page.locator("iframe[data-perspective-preload]")
+    ).not.toBeAttached();
+
+    // No loading indicator (preloaded iframe was already ready)
+    await expect(page.locator(".perspective-loading")).not.toBeAttached();
+
+    // onReady should have fired (replayed from preload ready state)
+    await page.waitForTimeout(100);
+    const events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "popup:ready")).toBe(true);
+  });
+
+  test("close hides popup, reopen reuses same iframe (no loading)", async ({
+    page,
+  }) => {
+    await page.goto("/preload-reuse.html");
+    await page.waitForTimeout(500);
+
+    // Open popup
+    await page.click("#init-popup-btn");
+    await expect(page.locator(".perspective-overlay")).toBeVisible();
+
+    // Mark the iframe so we can verify it's the same element after reopen
+    await page.evaluate(() => {
+      const iframe = document.querySelector(
+        ".perspective-modal iframe[data-perspective]"
+      ) as HTMLIFrameElement;
+      iframe.setAttribute("data-test-marker", "original");
+    });
+
+    // Close popup via ESC (hides, doesn't destroy)
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".perspective-overlay")).not.toBeVisible();
+
+    // Overlay should still be in the DOM (hidden, not removed)
+    const overlayCount = await page.locator(".perspective-overlay").count();
+    expect(overlayCount).toBe(1);
+
+    // Reopen by clicking the programmatic button again
+    await page.click("#init-popup-btn");
+    await expect(page.locator(".perspective-overlay")).toBeVisible();
+
+    // Still exactly one overlay (reused, not duplicated)
+    const overlayCountAfter = await page
+      .locator(".perspective-overlay")
+      .count();
+    expect(overlayCountAfter).toBe(1);
+
+    // Same iframe element (marker attribute still present)
+    const marker = await page
+      .locator(".perspective-modal iframe[data-perspective]")
+      .getAttribute("data-test-marker");
+    expect(marker).toBe("original");
+
+    // No loading indicator (iframe was alive the whole time)
+    await expect(page.locator(".perspective-loading")).not.toBeAttached();
+  });
+
+  test("autoInit preloads hidden iframe for button slider trigger when no popup exists", async ({
+    page,
+  }) => {
+    await page.goto("/preload-slider.html");
+
+    await page.waitForTimeout(500);
+
+    const preloadIframe = page.locator(
+      "iframe[data-perspective-preload='test-slider-only']"
+    );
+    await expect(preloadIframe).toBeAttached();
+
+    const opacity = await preloadIframe.evaluate(
+      (el) => (el as HTMLElement).style.opacity
+    );
+    expect(opacity).toBe("0");
+  });
+
+  test("preloaded slider opens without loading indicator and fires onReady", async ({
+    page,
+  }) => {
+    await page.goto("/preload-slider.html");
+
+    await page.waitForTimeout(500);
+
+    await expect(
+      page.locator("iframe[data-perspective-preload='test-slider-only']")
+    ).toBeAttached();
+
+    await page.click("#init-slider-btn");
+
+    await expect(page.locator(".perspective-slider")).toBeVisible();
+    await expect(
+      page.locator("iframe[data-perspective-preload]")
+    ).not.toBeAttached();
+    await expect(page.locator(".perspective-loading")).not.toBeAttached();
+
+    await page.waitForTimeout(100);
+    const events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "slider:ready")).toBe(true);
+  });
+
+  test("close hides slider, reopen reuses same iframe", async ({ page }) => {
+    await page.goto("/preload-reuse.html");
+
+    // Open slider
+    await page.click("#init-slider-btn");
+    await expect(page.locator(".perspective-slider")).toBeVisible();
+
+    // Mark iframe
+    await page.evaluate(() => {
+      const iframe = document.querySelector(
+        ".perspective-slider iframe[data-perspective]"
+      ) as HTMLIFrameElement;
+      iframe.setAttribute("data-test-marker", "original");
+    });
+
+    // Close via ESC
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".perspective-slider")).not.toBeVisible();
+
+    // Slider still in DOM
+    expect(await page.locator(".perspective-slider").count()).toBe(1);
+
+    // Reopen
+    await page.click("#init-slider-btn");
+    await expect(page.locator(".perspective-slider")).toBeVisible();
+
+    // Same iframe
+    const marker = await page
+      .locator(".perspective-slider iframe[data-perspective]")
+      .getAttribute("data-test-marker");
+    expect(marker).toBe("original");
+
+    // No loading indicator
+    await expect(page.locator(".perspective-loading")).not.toBeAttached();
+  });
+
+  test("destroyAll fully removes hidden popup and slider", async ({ page }) => {
+    await page.goto("/preload-reuse.html");
+
+    // Open popup, then hide it
+    await page.click("#init-popup-btn");
+    await expect(page.locator(".perspective-overlay")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".perspective-overlay")).not.toBeVisible();
+
+    // Open slider, then hide it
+    await page.click("#init-slider-btn");
+    await expect(page.locator(".perspective-slider")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".perspective-slider")).not.toBeVisible();
+
+    // Both hidden but still in DOM
+    expect(await page.locator(".perspective-overlay").count()).toBe(1);
+    expect(await page.locator(".perspective-slider").count()).toBe(1);
+
+    // destroyAll should fully remove them from the DOM
+    await page.click("#destroy-all-btn");
+
+    await expect(page.locator(".perspective-overlay")).not.toBeAttached();
+    await expect(page.locator(".perspective-slider")).not.toBeAttached();
+  });
+
+  test("onClose fires on hide, not on reopen", async ({ page }) => {
+    await page.goto("/preload-reuse.html");
+    await page.waitForTimeout(500);
+
+    // Open popup
+    await page.click("#init-popup-btn");
+    await expect(page.locator(".perspective-overlay")).toBeVisible();
+
+    // Clear events
+    await clearTestEvents(page);
+
+    // Close (hide) — should fire onClose
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(100);
+
+    let events = await getTestEvents(page);
+    const closeCount = events.filter(
+      (event) => event.name === "popup:close"
+    ).length;
+    expect(closeCount).toBe(1);
+
+    // Clear events again
+    await clearTestEvents(page);
+
+    // Reopen — should NOT fire onClose
+    await page.click("#init-popup-btn");
+    await expect(page.locator(".perspective-overlay")).toBeVisible();
+    await page.waitForTimeout(100);
+
+    events = await getTestEvents(page);
+    expect(events.some((event) => event.name === "popup:close")).toBe(false);
+  });
+});
+
+test.describe("Auto-Trigger Preload", () => {
+  test("auto-trigger popup is preloaded immediately before trigger fires", async ({
+    page,
+  }) => {
+    await page.goto("/auto-trigger.html");
+
+    // Preload should happen immediately for auto-triggers (no requestIdleCallback)
+    // Check within 200ms — well before the 500ms timeout trigger fires
+    await page.waitForTimeout(200);
+
+    // Preloaded iframe should exist
+    const preloadIframe = page.locator("iframe[data-perspective-preload]");
+    await expect(preloadIframe).toBeAttached();
+
+    // Popup should NOT be open yet (trigger hasn't fired)
+    await expect(page.locator(".perspective-overlay")).not.toBeVisible();
+  });
+
+  test("auto-trigger popup opens without loading indicator after preload", async ({
+    page,
+  }) => {
+    await page.goto("/auto-trigger.html");
+
+    // Wait for the 500ms timeout trigger to fire (with buffer)
+    await page.waitForTimeout(800);
+
+    // Popup should be open
+    await expect(page.locator(".perspective-overlay")).toBeVisible();
+
+    // Preloaded iframe should have been claimed
+    await expect(
+      page.locator("iframe[data-perspective-preload]")
+    ).not.toBeAttached();
+
+    // No loading indicator (was preloaded and ready)
+    await expect(page.locator(".perspective-loading")).not.toBeAttached();
+  });
+});
+
 test.describe("Float Bubble", () => {
   test("clicking bubble opens float window", async ({ page }) => {
     await page.goto("/manual-api.html");
@@ -757,21 +1065,27 @@ test.describe("Float Bubble", () => {
 
     // Bubble should be visible
     const bubble = page.locator("body > .perspective-float-bubble");
+    const floatWindow = page.locator("body > .perspective-float-window");
     await expect(bubble).toBeVisible();
+    await expect(floatWindow).toBeAttached();
 
-    // Initially no float window
-    await expect(page.locator(".perspective-float-window")).not.toBeVisible();
+    // Float window shell is already mounted, but hidden.
+    await expect(floatWindow).not.toBeVisible();
+    await expect(
+      floatWindow.locator("iframe[data-perspective]")
+    ).toBeAttached();
 
     // Click bubble to open
     await bubble.click();
 
     // Float window should appear
-    await expect(page.locator(".perspective-float-window")).toBeVisible();
+    await expect(floatWindow).toBeVisible();
+    await expect(page.locator(".perspective-loading")).not.toBeAttached();
 
     // Click bubble again to close
     await bubble.click();
 
     // Float window should be closed
-    await expect(page.locator(".perspective-float-window")).not.toBeVisible();
+    await expect(floatWindow).not.toBeVisible();
   });
 });

--- a/packages/sdk/e2e/fixtures/preload-reuse.html
+++ b/packages/sdk/e2e/fixtures/preload-reuse.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Preload & Reuse Test</title>
+  </head>
+  <body>
+    <h1>Preload & Reuse Test</h1>
+
+    <!--
+      Button triggers for autoInit to process.
+      autoInit will:
+        1. Attach click handlers to these buttons
+        2. Preload an iframe for the first button embed (popup priority)
+    -->
+    <button id="popup-trigger" data-perspective-popup="test-popup">
+      Open Popup
+    </button>
+
+    <button id="slider-trigger" data-perspective-slider="test-slider">
+      Open Slider
+    </button>
+
+    <!--
+      Programmatic controls that call Perspective.init() with callbacks.
+      Uses the same researchIds as the data-attribute buttons so they can
+      claim the preloaded iframe.
+    -->
+    <button id="init-popup-btn">Init Popup (programmatic)</button>
+    <button id="init-slider-btn">Init Slider (programmatic)</button>
+    <button id="destroy-all-btn">Destroy All</button>
+
+    <script>
+      window.__testEvents = [];
+      window.__handles = {};
+      window.__trackEvent = (name, data) => {
+        window.__testEvents.push({ name, data, timestamp: Date.now() });
+      };
+    </script>
+
+    <script src="/sdk/perspective.global.js"></script>
+
+    <script>
+      document
+        .getElementById("init-popup-btn")
+        .addEventListener("click", () => {
+          window.__handles.popup = Perspective.init({
+            researchId: "test-popup",
+            type: "popup",
+            onReady: () => window.__trackEvent("popup:ready"),
+            onClose: () => window.__trackEvent("popup:close"),
+            onSubmit: () => window.__trackEvent("popup:submit"),
+          });
+        });
+
+      document
+        .getElementById("init-slider-btn")
+        .addEventListener("click", () => {
+          window.__handles.slider = Perspective.init({
+            researchId: "test-slider",
+            type: "slider",
+            onReady: () => window.__trackEvent("slider:ready"),
+            onClose: () => window.__trackEvent("slider:close"),
+          });
+        });
+
+      document
+        .getElementById("destroy-all-btn")
+        .addEventListener("click", () => {
+          Perspective.destroyAll();
+          window.__trackEvent("destroyAll");
+        });
+    </script>
+  </body>
+</html>

--- a/packages/sdk/e2e/fixtures/preload-slider.html
+++ b/packages/sdk/e2e/fixtures/preload-slider.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Slider Preload Test</title>
+  </head>
+  <body>
+    <h1>Slider Preload Test</h1>
+
+    <button id="slider-trigger" data-perspective-slider="test-slider-only">
+      Open Slider
+    </button>
+
+    <button id="init-slider-btn">Init Slider (programmatic)</button>
+
+    <script>
+      window.__testEvents = [];
+      window.__handles = {};
+      window.__trackEvent = (name, data) => {
+        window.__testEvents.push({ name, data, timestamp: Date.now() });
+      };
+    </script>
+
+    <script src="/sdk/perspective.global.js"></script>
+
+    <script>
+      document
+        .getElementById("init-slider-btn")
+        .addEventListener("click", () => {
+          window.__handles.slider = Perspective.init({
+            researchId: "test-slider-only",
+            type: "slider",
+            onReady: () => window.__trackEvent("slider:ready"),
+            onClose: () => window.__trackEvent("slider:close"),
+          });
+        });
+    </script>
+  </body>
+</html>

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -51,7 +51,7 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:e2e": "playwright test",
+    "test:e2e": "pnpm build && playwright test",
     "test:ssr": "node -e \"require('./dist/index.cjs'); require('./dist/constants.cjs');\" && echo 'SSR safe ✓'"
   },
   "keywords": [

--- a/packages/sdk/src/auto-open.ts
+++ b/packages/sdk/src/auto-open.ts
@@ -1,0 +1,39 @@
+import type { EmbedConfig, ShowOnce, TriggerConfig } from "./types";
+import { openPopup } from "./popup";
+import { shouldShow, markShown, setupTrigger } from "./triggers";
+
+export interface AutoOpenPopupOptions extends Omit<
+  EmbedConfig,
+  "type" | "autoOpen"
+> {
+  trigger: TriggerConfig;
+  showOnce?: ShowOnce;
+  onTriggered?: () => void;
+  onOpen?: () => void;
+}
+
+export function setupAutoOpenPopup(
+  options: AutoOpenPopupOptions
+): (() => void) | null {
+  const {
+    trigger,
+    showOnce = "session",
+    onTriggered,
+    onOpen,
+    ...config
+  } = options;
+
+  if (!shouldShow(config.researchId, showOnce)) {
+    return null;
+  }
+
+  return setupTrigger(trigger, () => {
+    markShown(config.researchId, showOnce);
+    onTriggered?.();
+    if (onOpen) {
+      onOpen();
+    } else {
+      openPopup(config);
+    }
+  });
+}

--- a/packages/sdk/src/browser.test.ts
+++ b/packages/sdk/src/browser.test.ts
@@ -11,6 +11,7 @@ import {
   createFloatBubble,
   createChatBubble,
   createFullpage,
+  isToggleable,
 } from "./browser";
 import { getPersistedOpenState, setPersistedOpenState } from "./state";
 
@@ -161,14 +162,45 @@ describe("browser entry", () => {
       expect(document.querySelector(".perspective-slider")).toBeFalsy();
     });
 
-    it("preserves persisted open state for teardown", () => {
+    it("clears persisted open state when explicitly destroyed", () => {
       init({ researchId: "test1", type: "popup" });
 
       destroyAll();
 
       expect(
         getPersistedOpenState({ researchId: "test1", type: "popup" })
-      ).toBe(true);
+      ).toBe(false);
+    });
+
+    it("clears cached config so reinitializing refetches button theme data", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          primaryColor: "#7c3aed",
+          textColor: "#ffffff",
+          darkPrimaryColor: "#a78bfa",
+          darkTextColor: "#ffffff",
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      document.body.innerHTML = `
+        <button data-perspective-popup="res1">Open</button>
+      `;
+
+      autoInit();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      destroyAll();
+      autoInit();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
     it("resets data-perspective-initialized so autoInit can re-process elements", () => {
@@ -212,6 +244,316 @@ describe("browser entry", () => {
           .querySelector("[data-perspective-popup]")!
           .hasAttribute("data-perspective-initialized")
       ).toBe(true);
+    });
+
+    it("removes popup click handlers before reinitializing the same DOM", () => {
+      document.body.innerHTML = `
+        <button data-perspective-popup="res1">Open</button>
+      `;
+
+      const appendSpy = vi.spyOn(document.body, "appendChild");
+
+      autoInit();
+      destroyAll();
+      autoInit();
+
+      const button = document.querySelector(
+        "[data-perspective-popup]"
+      ) as HTMLButtonElement;
+      button.click();
+
+      const popupAppends = appendSpy.mock.calls.filter(([node]) => {
+        return (
+          node instanceof HTMLElement &&
+          node.classList.contains("perspective-overlay")
+        );
+      });
+
+      expect(popupAppends).toHaveLength(1);
+    });
+
+    it("removes slider click handlers before reinitializing the same DOM", () => {
+      document.body.innerHTML = `
+        <button data-perspective-slider="res2">Slide</button>
+      `;
+
+      const appendSpy = vi.spyOn(document.body, "appendChild");
+
+      autoInit();
+      destroyAll();
+      autoInit();
+
+      const button = document.querySelector(
+        "[data-perspective-slider]"
+      ) as HTMLButtonElement;
+      button.click();
+
+      const sliderAppends = appendSpy.mock.calls.filter(([node]) => {
+        return (
+          node instanceof HTMLElement &&
+          node.classList.contains("perspective-slider")
+        );
+      });
+
+      expect(sliderAppends).toHaveLength(1);
+    });
+  });
+
+  describe("hide-on-close and reuse", () => {
+    const host = "https://getperspective.ai";
+
+    it("reuses hidden popup on second init() call instead of recreating", () => {
+      const handle1 = init({ researchId: "test", type: "popup", host });
+      const iframe1 = handle1.iframe;
+
+      expect(document.querySelector(".perspective-overlay")).toBeTruthy();
+
+      // Close (hide) the popup
+      const closeBtn = document.querySelector(
+        ".perspective-close"
+      ) as HTMLElement;
+      closeBtn.click();
+
+      // Overlay hidden but still in DOM
+      const overlay = document.querySelector(
+        ".perspective-overlay"
+      ) as HTMLElement;
+      expect(overlay.style.display).toBe("none");
+
+      // Re-open via init() — should reuse the hidden instance
+      const handle2 = init({ researchId: "test", type: "popup", host });
+
+      // Same handle returned (same iframe, no recreation)
+      expect(handle2).toBe(handle1);
+      expect(handle2.iframe).toBe(iframe1);
+
+      // Overlay visible again
+      expect(overlay.style.display).toBe("");
+
+      handle2.unmount();
+    });
+
+    it("reuses hidden slider on second init() call", () => {
+      const handle1 = init({ researchId: "test", type: "slider", host });
+      const iframe1 = handle1.iframe;
+
+      // Close (hide)
+      const closeBtn = document.querySelector(
+        ".perspective-slider .perspective-close"
+      ) as HTMLElement;
+      closeBtn.click();
+
+      const slider = document.querySelector(
+        ".perspective-slider"
+      ) as HTMLElement;
+      expect(slider.style.display).toBe("none");
+
+      // Re-open
+      const handle2 = init({ researchId: "test", type: "slider", host });
+      expect(handle2).toBe(handle1);
+      expect(handle2.iframe).toBe(iframe1);
+      expect(slider.style.display).toBe("");
+
+      handle2.unmount();
+    });
+
+    it("updates config when reusing hidden instance", () => {
+      const onSubmit1 = vi.fn();
+      const onSubmit2 = vi.fn();
+
+      const handle = init({
+        researchId: "test",
+        type: "popup",
+        host,
+        onSubmit: onSubmit1,
+      });
+
+      // Close
+      expect(isToggleable(handle)).toBe(true);
+      if (isToggleable(handle)) handle.hide();
+
+      // Reopen with different callback
+      init({
+        researchId: "test",
+        type: "popup",
+        host,
+        onSubmit: onSubmit2,
+      });
+
+      // Send submit message — should use new callback
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "perspective:submit",
+            researchId: "test",
+          },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+
+      expect(onSubmit2).toHaveBeenCalledTimes(1);
+      expect(onSubmit1).not.toHaveBeenCalled();
+
+      handle.unmount();
+    });
+
+    it("replays ready callbacks when reusing a ready hidden popup", () => {
+      const onReady = vi.fn();
+
+      const handle = init({ researchId: "test", type: "popup", host });
+
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "perspective:ready",
+            researchId: "test",
+          },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+
+      expect(isToggleable(handle)).toBe(true);
+      if (isToggleable(handle)) {
+        handle.hide();
+      }
+
+      const reopened = init({
+        researchId: "test",
+        type: "popup",
+        host,
+        onReady,
+      });
+
+      expect(reopened).toBe(handle);
+      expect(onReady).toHaveBeenCalledTimes(1);
+
+      reopened.unmount();
+    });
+
+    it("does not reuse hidden popup when iframe-defining config changes", () => {
+      const handle1 = init({
+        researchId: "test",
+        type: "popup",
+        host,
+        params: { step: "1" },
+      });
+      const iframe1 = handle1.iframe;
+
+      expect(isToggleable(handle1)).toBe(true);
+      if (isToggleable(handle1)) {
+        handle1.hide();
+      }
+
+      const handle2 = init({
+        researchId: "test",
+        type: "popup",
+        host,
+        params: { step: "2" },
+      });
+
+      expect(handle2).not.toBe(handle1);
+      expect(handle2.iframe).not.toBe(iframe1);
+
+      handle2.unmount();
+    });
+
+    it("does not reuse hidden popup when disableClose changes", () => {
+      const handle1 = init({
+        researchId: "test",
+        type: "popup",
+        host,
+        disableClose: false,
+      });
+      const iframe1 = handle1.iframe;
+
+      expect(isToggleable(handle1)).toBe(true);
+      if (isToggleable(handle1)) {
+        handle1.hide();
+      }
+
+      const handle2 = init({
+        researchId: "test",
+        type: "popup",
+        host,
+        disableClose: true,
+      });
+
+      expect(handle2).not.toBe(handle1);
+      expect(handle2.iframe).not.toBe(iframe1);
+      expect(
+        (document.querySelector(".perspective-close") as HTMLElement).style
+          .display
+      ).toBe("none");
+
+      handle2.unmount();
+    });
+
+    it("destroy() fully removes and allows fresh creation", () => {
+      const handle1 = init({ researchId: "test", type: "popup", host });
+      const iframe1 = handle1.iframe;
+
+      // Full destroy (not hide)
+      destroy("test");
+      expect(document.querySelector(".perspective-overlay")).toBeFalsy();
+
+      // New init creates a fresh instance
+      const handle2 = init({ researchId: "test", type: "popup", host });
+      expect(handle2).not.toBe(handle1);
+      expect(handle2.iframe).not.toBe(iframe1);
+      expect(document.querySelector(".perspective-overlay")).toBeTruthy();
+
+      handle2.unmount();
+    });
+
+    it("does not reuse hidden popup when type changes to slider", () => {
+      const handle1 = init({ researchId: "test", type: "popup", host });
+
+      // Hide popup
+      expect(isToggleable(handle1)).toBe(true);
+      if (isToggleable(handle1)) handle1.hide();
+
+      // Init with different type — should NOT reuse the hidden popup
+      const handle2 = init({ researchId: "test", type: "slider", host });
+      expect(handle2).not.toBe(handle1);
+      expect(handle2.type).toBe("slider");
+      expect(document.querySelector(".perspective-slider")).toBeTruthy();
+
+      handle2.unmount();
+    });
+
+    it("destroyAll() fully cleans up hidden instances", () => {
+      init({ researchId: "test1", type: "popup", host });
+      init({ researchId: "test2", type: "slider", host });
+
+      // Hide both
+      (
+        document.querySelector(
+          ".perspective-overlay .perspective-close"
+        ) as HTMLElement
+      ).click();
+      (
+        document.querySelector(
+          ".perspective-slider .perspective-close"
+        ) as HTMLElement
+      ).click();
+
+      // Both hidden but in DOM
+      expect(
+        (document.querySelector(".perspective-overlay") as HTMLElement).style
+          .display
+      ).toBe("none");
+      expect(
+        (document.querySelector(".perspective-slider") as HTMLElement).style
+          .display
+      ).toBe("none");
+
+      destroyAll();
+
+      // Both fully removed
+      expect(document.querySelector(".perspective-overlay")).toBeFalsy();
+      expect(document.querySelector(".perspective-slider")).toBeFalsy();
     });
   });
 
@@ -405,6 +747,7 @@ describe("browser entry", () => {
         type: "slider",
         open: true,
       });
+
       document.body.innerHTML = `
         <button data-perspective-slider="test-slider">Open</button>
       `;
@@ -412,6 +755,23 @@ describe("browser entry", () => {
       autoInit();
 
       expect(document.querySelector(".perspective-slider")).toBeTruthy();
+    });
+
+    it("preloads the first slider button when no popup button exists", () => {
+      vi.useFakeTimers();
+      document.body.innerHTML = `
+        <button data-perspective-slider="test-slider">Open</button>
+      `;
+
+      autoInit();
+      vi.advanceTimersByTime(200);
+
+      const preloadIframe = document.querySelector(
+        "iframe[data-perspective-preload='test-slider']"
+      ) as HTMLIFrameElement | null;
+
+      expect(preloadIframe).toBeTruthy();
+      expect(preloadIframe?.style.opacity).toBe("0");
     });
 
     it("initializes float from data-perspective-float", () => {
@@ -422,6 +782,14 @@ describe("browser entry", () => {
       autoInit();
 
       expect(document.querySelector(".perspective-float-bubble")).toBeTruthy();
+      const floatWindow = document.querySelector(
+        ".perspective-float-window"
+      ) as HTMLElement | null;
+      expect(floatWindow).toBeTruthy();
+      expect(floatWindow?.style.display).toBe("none");
+      expect(
+        floatWindow?.querySelector("iframe[data-perspective]")
+      ).toBeTruthy();
     });
 
     it("initializes float from legacy data-perspective-chat", () => {
@@ -605,6 +973,86 @@ describe("browser entry", () => {
       const img = bubble.querySelector("img");
       expect(img).toBeTruthy();
       expect(img!.src).toBe("https://example.com/avatar.png");
+    });
+
+    it("ignores stale float config fetches after destroyAll and reinit", async () => {
+      const flushPromises = async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      };
+
+      let resolveFirstFetch:
+        | ((value: { ok: boolean; json: () => Promise<unknown> }) => void)
+        | undefined;
+      let resolveSecondFetch:
+        | ((value: { ok: boolean; json: () => Promise<unknown> }) => void)
+        | undefined;
+
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockImplementationOnce(
+            () =>
+              new Promise((resolve) => {
+                resolveFirstFetch = resolve;
+              })
+          )
+          .mockImplementationOnce(
+            () =>
+              new Promise((resolve) => {
+                resolveSecondFetch = resolve;
+              })
+          )
+      );
+
+      document.body.innerHTML = `
+        <div data-perspective-float="test-race"></div>
+      `;
+      autoInit();
+
+      const firstBubble = document.querySelector(
+        ".perspective-float-bubble"
+      ) as HTMLElement;
+      expect(firstBubble.style.backgroundColor).toBe("#7c3aed");
+
+      destroyAll();
+      document.body.innerHTML = `
+        <div data-perspective-float="test-race"></div>
+      `;
+      autoInit();
+
+      const secondBubble = document.querySelector(
+        ".perspective-float-bubble"
+      ) as HTMLElement;
+      expect(secondBubble).not.toBe(firstBubble);
+
+      resolveFirstFetch?.({
+        ok: true,
+        json: async () => ({
+          primaryColor: "#ff0000",
+          textColor: "#ffffff",
+          darkPrimaryColor: "#ff0000",
+          darkTextColor: "#ffffff",
+        }),
+      });
+      await flushPromises();
+
+      expect(secondBubble.style.backgroundColor).toBe("#7c3aed");
+
+      resolveSecondFetch?.({
+        ok: true,
+        json: async () => ({
+          primaryColor: "#0000ff",
+          textColor: "#ffffff",
+          darkPrimaryColor: "#0000ff",
+          darkTextColor: "#ffffff",
+        }),
+      });
+      await flushPromises();
+
+      expect(secondBubble.style.backgroundColor).toBe("#0000ff");
     });
   });
 });

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -21,16 +21,12 @@ import type {
   EmbedConfig,
   EmbedHandle,
   FloatHandle,
+  ToggleableHandle,
   ThemeConfig,
 } from "./types";
 import { DATA_ATTRS, THEME_VALUES } from "./constants";
-import {
-  parseTriggerAttr,
-  parseShowOnceAttr,
-  setupTrigger,
-  shouldShow,
-  markShown,
-} from "./triggers";
+import { markShown, parseTriggerAttr, parseShowOnceAttr } from "./triggers";
+import { setupAutoOpenPopup } from "./auto-open";
 import { createWidget } from "./widget";
 import { openPopup } from "./popup";
 import { openSlider } from "./slider";
@@ -39,12 +35,34 @@ import { createFullpage } from "./fullpage";
 import { configure, getConfig, hasDom, getHost } from "./config";
 import { getPersistedOpenState } from "./state";
 import { resolveIsDark } from "./utils";
+import { getTimer, removeTimer } from "./timing";
+import { injectResourceHints } from "./hints";
+import { preloadIframe, destroyPreloaded } from "./preload";
 
 // Track all active instances
 const instances: Map<string, EmbedHandle | FloatHandle> = new Map();
 
+export function isToggleable(
+  handle: EmbedHandle | FloatHandle
+): handle is ToggleableHandle {
+  return "show" in handle && "hide" in handle;
+}
+
 // Track auto-open trigger cleanups (keyed by researchId)
 const triggerCleanups: Map<string, () => void> = new Map();
+const clickHandlerCleanups: Map<HTMLElement, () => void> = new Map();
+
+// Track pending idle preload so it can be cancelled on destroy
+let pendingPreloadHandle: number | null = null;
+
+function cancelPendingPreload(): void {
+  if (pendingPreloadHandle === null) return;
+  if ("cancelIdleCallback" in window) {
+    (window as Window).cancelIdleCallback(pendingPreloadHandle);
+  }
+  clearTimeout(pendingPreloadHandle);
+  pendingPreloadHandle = null;
+}
 
 // Theme config cache
 type EmbedApiConfig = ThemeConfig & {
@@ -58,6 +76,13 @@ type ButtonStyleConfig = {
   theme?: EmbedConfig["theme"];
   brand?: EmbedConfig["brand"];
 };
+type ThemeAwareFloatHandle = FloatHandle & {
+  update: (
+    options: Parameters<FloatHandle["update"]>[0] & {
+      _themeConfig?: ThemeConfig;
+    }
+  ) => void;
+};
 const styledButtons = new Map<HTMLElement, ButtonStyleConfig>();
 let buttonThemeMediaQuery: MediaQueryList | null = null;
 
@@ -67,6 +92,15 @@ const DEFAULT_THEME: ThemeConfig = {
   darkPrimaryColor: "#a78bfa",
   darkTextColor: "#ffffff",
 };
+const shouldWarnConfigFetch =
+  typeof process !== "undefined" && process.env?.NODE_ENV === "development";
+
+function warnConfigFetch(researchId: string, reason: string): void {
+  if (!shouldWarnConfigFetch || typeof console === "undefined") return;
+  console.warn(
+    `[Perspective] Failed to load embed config for ${researchId}: ${reason}`
+  );
+}
 
 /**
  * Fetch theme config from API (cached)
@@ -79,11 +113,18 @@ async function fetchConfig(researchId: string): Promise<EmbedApiConfig> {
   try {
     const host = getHost();
     const res = await fetch(`${host}/api/v1/embed/config/${researchId}`);
-    if (!res.ok) return DEFAULT_THEME;
+    if (!res.ok) {
+      warnConfigFetch(researchId, `HTTP ${res.status}`);
+      return DEFAULT_THEME;
+    }
     const config = (await res.json()) as EmbedApiConfig;
     configCache.set(researchId, config);
     return config;
-  } catch {
+  } catch (error) {
+    warnConfigFetch(
+      researchId,
+      error instanceof Error ? error.message : String(error)
+    );
     return DEFAULT_THEME;
   }
 }
@@ -295,9 +336,22 @@ function init(config: EmbedConfig): EmbedHandle | FloatHandle {
   // Normalize legacy "chat" type to "float"
   const type = config.type === "chat" ? "float" : (config.type ?? "widget");
 
-  // Destroy existing instance for this research
-  if (instances.has(researchId)) {
-    instances.get(researchId)!.unmount();
+  // Reuse hidden popup/slider instead of recreating (must match type)
+  const existing = instances.get(researchId);
+  if (
+    existing &&
+    isToggleable(existing) &&
+    !existing.isOpen &&
+    existing.type === type &&
+    existing.canReuse(config)
+  ) {
+    existing.update(config);
+    existing.show();
+    existing.replayOpenCallbacks();
+    return existing;
+  }
+  if (existing) {
+    existing.unmount();
     instances.delete(researchId);
   }
 
@@ -375,16 +429,25 @@ function destroy(researchId: string): void {
   if (instance) {
     instance.destroy();
     instances.delete(researchId);
+    removeTimer(researchId);
   }
 }
 
 function destroyAll(): void {
-  instances.forEach((instance) => instance.unmount());
+  instances.forEach((instance, researchId) => {
+    instance.destroy();
+    removeTimer(researchId);
+  });
   instances.clear();
   triggerCleanups.forEach((cleanup) => cleanup());
   triggerCleanups.clear();
+  clickHandlerCleanups.forEach((cleanup) => cleanup());
+  clickHandlerCleanups.clear();
   styledButtons.clear();
+  configCache.clear();
   teardownButtonThemeListener();
+  cancelPendingPreload();
+  destroyPreloaded();
   // Reset initialized flags so autoInit can re-process elements cleanly
   if (hasDom()) {
     document
@@ -409,6 +472,7 @@ function autoInit(): void {
       if (researchId && !instances.has(researchId)) {
         const params = parseParamsAttr(el);
         const brandConfig = extractBrandConfig(el);
+        getTimer(researchId).mark("sdk:autoInit");
         mount(el, { researchId, type: "widget", params, ...brandConfig });
       }
     });
@@ -421,6 +485,7 @@ function autoInit(): void {
       if (researchId && !instances.has(researchId)) {
         const params = parseParamsAttr(el);
         const brandConfig = extractBrandConfig(el);
+        getTimer(researchId).mark("sdk:autoInit");
         init({ researchId, type: "fullpage", params, ...brandConfig });
       }
     });
@@ -455,20 +520,25 @@ function autoInit(): void {
             ...brandConfig,
           });
         } else if (persistedOpen !== false) {
-          // Auto-open mode: trigger-based, no button styling
           try {
             const trigger = parseTriggerAttr(autoOpenAttr);
             const showOnce = parseShowOnceAttr(
               el.getAttribute(DATA_ATTRS.showOnce)
             );
+            triggerCleanups.get(researchId)?.();
 
-            if (shouldShow(researchId, showOnce)) {
-              // Clean up any existing trigger for this researchId
-              triggerCleanups.get(researchId)?.();
-
-              const cleanup = setupTrigger(trigger, () => {
+            const cleanup = setupAutoOpenPopup({
+              researchId,
+              trigger,
+              showOnce,
+              params,
+              brand: brandConfig.brand,
+              theme: brandConfig.theme,
+              onTriggered: () => {
                 triggerCleanups.delete(researchId);
                 markShown(researchId, showOnce);
+              },
+              onOpen: () => {
                 init({
                   researchId,
                   type: "popup",
@@ -476,18 +546,26 @@ function autoInit(): void {
                   disableClose,
                   ...brandConfig,
                 });
-              });
+              },
+            });
+
+            if (cleanup) {
               triggerCleanups.set(researchId, cleanup);
             }
           } catch (e) {
-            console.warn("[Perspective]", (e as Error).message);
+            console.warn(
+              "[Perspective]",
+              e instanceof Error ? e.message : String(e)
+            );
           }
         }
       } else {
         // Click-to-open mode: styled button
         styleButton(el, DEFAULT_THEME, brandConfig);
-        el.addEventListener("click", (e) => {
+        clickHandlerCleanups.get(el)?.();
+        const clickHandler = (e: MouseEvent) => {
           e.preventDefault();
+          getTimer(researchId).mark("sdk:triggerOpen");
           init({
             researchId,
             type: "popup",
@@ -495,6 +573,10 @@ function autoInit(): void {
             disableClose,
             ...brandConfig,
           });
+        };
+        el.addEventListener("click", clickHandler);
+        clickHandlerCleanups.set(el, () => {
+          el.removeEventListener("click", clickHandler);
         });
         fetchConfig(researchId).then((config) => {
           styleButton(el, config, brandConfig);
@@ -529,8 +611,10 @@ function autoInit(): void {
           type: "slider",
         });
         styleButton(el, DEFAULT_THEME, brandConfig);
-        el.addEventListener("click", (e) => {
+        clickHandlerCleanups.get(el)?.();
+        const clickHandler = (e: MouseEvent) => {
           e.preventDefault();
+          getTimer(researchId).mark("sdk:triggerOpen");
           init({
             researchId,
             type: "slider",
@@ -538,6 +622,10 @@ function autoInit(): void {
             disableClose,
             ...brandConfig,
           });
+        };
+        el.addEventListener("click", clickHandler);
+        clickHandlerCleanups.set(el, () => {
+          el.removeEventListener("click", clickHandler);
         });
         fetchConfig(researchId).then((config) => {
           styleButton(el, config, brandConfig);
@@ -566,6 +654,7 @@ function autoInit(): void {
       const params = parseParamsAttr(floatEl);
       const brandConfig = extractBrandConfig(floatEl);
       const launcherConfig = extractLauncherConfig(floatEl);
+      getTimer(researchId).mark("sdk:autoInit");
       const floatHandle = init({
         researchId,
         type: "float",
@@ -576,45 +665,80 @@ function autoInit(): void {
       } as EmbedConfig & { _themeConfig: ThemeConfig });
 
       fetchConfig(researchId).then((config) => {
-        // Update bubble color with fetched theme
-        const bubble = document.querySelector<HTMLElement>(
-          '[data-perspective="float-bubble"]'
-        );
-        if (bubble && !floatEl.hasAttribute(DATA_ATTRS.noStyle)) {
-          // Only apply theme colors if launcher.style didn't override backgroundColor
-          if (!launcherConfig?.style?.backgroundColor) {
-            const isDark = resolveIsDark(brandConfig.theme);
-            const bg = isDark
-              ? (brandConfig.brand?.dark?.primary ?? config.darkPrimaryColor)
-              : (brandConfig.brand?.light?.primary ?? config.primaryColor);
-            bubble.style.setProperty("--perspective-float-bg", bg);
-            bubble.style.setProperty(
-              "--perspective-float-shadow",
-              `0 4px 12px ${bg}66`
-            );
-            bubble.style.setProperty(
-              "--perspective-float-shadow-hover",
-              `0 6px 16px ${bg}80`
-            );
-            bubble.style.backgroundColor = bg;
-            bubble.style.boxShadow = `0 4px 12px ${bg}66`;
-          }
-        }
-
         if (
           floatHandle.type === "float" &&
           instances.get(researchId) === floatHandle
         ) {
           const channels =
             config.channel ?? config.allowedChannels ?? undefined;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (floatHandle.update as any)({
+          const themeAwareFloatHandle = floatHandle as ThemeAwareFloatHandle;
+          themeAwareFloatHandle.update({
             channel: channels,
             welcomeMessage: config.welcomeMessage,
             _themeConfig: config,
           });
         }
       });
+    }
+  }
+
+  // Preload iframe for the first button-triggered or auto-triggered embed
+  // Priority: button embeds first (user will click), then auto-trigger embeds
+  const firstButtonEmbed =
+    document.querySelector<HTMLElement>(
+      `[${DATA_ATTRS.popup}]:not([${DATA_ATTRS.autoOpen}])`
+    ) ?? document.querySelector<HTMLElement>(`[${DATA_ATTRS.slider}]`);
+
+  const firstAutoTriggerEmbed = !firstButtonEmbed
+    ? document.querySelector<HTMLElement>(
+        `[${DATA_ATTRS.popup}][${DATA_ATTRS.autoOpen}]`
+      )
+    : null;
+
+  const preloadTarget = firstButtonEmbed ?? firstAutoTriggerEmbed;
+
+  if (preloadTarget) {
+    const preloadResearchId =
+      preloadTarget.getAttribute(DATA_ATTRS.popup) ??
+      preloadTarget.getAttribute(DATA_ATTRS.slider);
+    if (preloadResearchId && !instances.has(preloadResearchId)) {
+      const preloadType = preloadTarget.hasAttribute(DATA_ATTRS.popup)
+        ? ("popup" as const)
+        : ("slider" as const);
+      const preloadParams = parseParamsAttr(preloadTarget);
+      const preloadBrand = extractBrandConfig(preloadTarget);
+      const preloadHost = getHost();
+
+      const doPreload = () => {
+        pendingPreloadHandle = null;
+        // Re-check: user may have clicked before idle callback fired
+        if (instances.has(preloadResearchId)) return;
+        preloadIframe(
+          preloadResearchId,
+          preloadType,
+          preloadHost,
+          preloadParams,
+          preloadBrand.brand,
+          preloadBrand.theme
+        );
+      };
+
+      if (firstButtonEmbed) {
+        // Button embeds: defer to idle time
+        if ("requestIdleCallback" in window) {
+          pendingPreloadHandle = (window as Window).requestIdleCallback(
+            doPreload
+          ) as unknown as number;
+        } else {
+          pendingPreloadHandle = setTimeout(
+            doPreload,
+            200
+          ) as unknown as number;
+        }
+      } else {
+        // Auto-trigger embeds: preload immediately (trigger timer is already ticking)
+        doPreload();
+      }
     }
   }
 }
@@ -667,6 +791,9 @@ if (hasDom() && !window.__PERSPECTIVE_SDK_INITIALIZED__) {
       script
     );
   }
+
+  // Inject resource hints early — start DNS/TLS before iframe creation
+  injectResourceHints(getHost());
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", autoInit, { once: true });

--- a/packages/sdk/src/float.test.ts
+++ b/packages/sdk/src/float.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createFloatBubble, createChatBubble } from "./float";
+import { preloadIframe, destroyPreloaded } from "./preload";
 import * as config from "./config";
 import { getPersistedOpenState, setPersistedOpenState } from "./state";
+
+type FloatBubbleConfig = Parameters<typeof createFloatBubble>[0];
 
 describe("createFloatBubble", () => {
   beforeEach(() => {
@@ -9,6 +12,7 @@ describe("createFloatBubble", () => {
   });
 
   afterEach(() => {
+    destroyPreloaded();
     document.body.innerHTML = "";
     sessionStorage.clear();
     vi.useRealTimers();
@@ -24,6 +28,49 @@ describe("createFloatBubble", () => {
     expect(handle.type).toBe("float");
     expect(handle.isOpen).toBe(false);
     expect(document.querySelector(".perspective-float-bubble")).toBeTruthy();
+
+    handle.unmount();
+  });
+
+  it("creates a hidden float window shell when the bubble is created", () => {
+    const handle = createFloatBubble({
+      researchId: "test-research-id",
+    });
+
+    const floatWindow = document.querySelector(
+      ".perspective-float-window"
+    ) as HTMLElement | null;
+    const iframe = floatWindow?.querySelector(
+      "iframe[data-perspective]"
+    ) as HTMLIFrameElement | null;
+
+    expect(floatWindow).toBeTruthy();
+    expect(floatWindow?.style.display).toBe("none");
+    expect(iframe).toBeTruthy();
+
+    handle.unmount();
+  });
+
+  it("claims an existing preloaded float iframe when the bubble is created", () => {
+    preloadIframe("test-research-id", "float", "https://getperspective.ai");
+    const existingPreload = document.querySelector(
+      "iframe[data-perspective-preload='test-research-id']"
+    );
+
+    const handle = createFloatBubble({
+      researchId: "test-research-id",
+      host: "https://getperspective.ai",
+    });
+
+    expect(handle.iframe).toBe(existingPreload);
+    expect(
+      existingPreload?.getAttribute("data-perspective-preload")
+    ).toBeNull();
+    expect(
+      document.querySelector(
+        ".perspective-float-window iframe[data-perspective]"
+      )
+    ).toBe(existingPreload);
 
     handle.unmount();
   });
@@ -98,29 +145,38 @@ describe("createFloatBubble", () => {
     expect(() => handle.toggle()).not.toThrow();
   });
 
-  it("open() opens float window", () => {
+  it("keeps the float window hidden until opened", () => {
     const handle = createFloatBubble({
       researchId: "test-research-id",
     });
 
+    const floatWindow = document.querySelector(
+      ".perspective-float-window"
+    ) as HTMLElement;
+    expect(floatWindow).toBeTruthy();
+    expect(floatWindow.style.display).toBe("none");
     expect(handle.isOpen).toBe(false);
-    expect(document.querySelector(".perspective-float-window")).toBeFalsy();
-
-    handle.open();
-
-    expect(handle.isOpen).toBe(true);
-    expect(document.querySelector(".perspective-float-window")).toBeTruthy();
-    expect(
-      getPersistedOpenState({
-        researchId: "test-research-id",
-        type: "float",
-      })
-    ).toBe(true);
 
     handle.unmount();
   });
 
-  it("close() closes float window", () => {
+  it("open() shows float window", () => {
+    const handle = createFloatBubble({
+      researchId: "test-research-id",
+    });
+
+    handle.open();
+
+    const floatWindow = document.querySelector(
+      ".perspective-float-window"
+    ) as HTMLElement;
+    expect(handle.isOpen).toBe(true);
+    expect(floatWindow.style.display).toBe("");
+
+    handle.unmount();
+  });
+
+  it("close() hides float window", () => {
     const onClose = vi.fn();
     const handle = createFloatBubble({
       researchId: "test-research-id",
@@ -129,12 +185,14 @@ describe("createFloatBubble", () => {
 
     handle.open();
     expect(handle.isOpen).toBe(true);
-    expect(document.querySelector(".perspective-float-window")).toBeTruthy();
 
     handle.close();
 
+    const floatWindow = document.querySelector(
+      ".perspective-float-window"
+    ) as HTMLElement;
     expect(handle.isOpen).toBe(false);
-    expect(document.querySelector(".perspective-float-window")).toBeFalsy();
+    expect(floatWindow.style.display).toBe("none");
     expect(onClose).toHaveBeenCalled();
     expect(
       getPersistedOpenState({
@@ -144,7 +202,7 @@ describe("createFloatBubble", () => {
     ).toBe(false);
   });
 
-  it("toggle() toggles float window", () => {
+  it("toggle() toggles float window visibility", () => {
     const handle = createFloatBubble({
       researchId: "test-research-id",
     });
@@ -152,17 +210,20 @@ describe("createFloatBubble", () => {
     expect(handle.isOpen).toBe(false);
 
     handle.toggle();
+    const floatWindow = document.querySelector(
+      ".perspective-float-window"
+    ) as HTMLElement;
     expect(handle.isOpen).toBe(true);
-    expect(document.querySelector(".perspective-float-window")).toBeTruthy();
+    expect(floatWindow.style.display).toBe("");
 
     handle.toggle();
     expect(handle.isOpen).toBe(false);
-    expect(document.querySelector(".perspective-float-window")).toBeFalsy();
+    expect(floatWindow.style.display).toBe("none");
 
     handle.unmount();
   });
 
-  it("clicking bubble toggles float window", () => {
+  it("clicking bubble toggles float window visibility", () => {
     const handle = createFloatBubble({
       researchId: "test-research-id",
     });
@@ -173,17 +234,20 @@ describe("createFloatBubble", () => {
     expect(bubble).toBeTruthy();
 
     bubble.click();
+    const floatWindow = document.querySelector(
+      ".perspective-float-window"
+    ) as HTMLElement;
     expect(handle.isOpen).toBe(true);
-    expect(document.querySelector(".perspective-float-window")).toBeTruthy();
+    expect(floatWindow.style.display).toBe("");
 
     bubble.click();
     expect(handle.isOpen).toBe(false);
-    expect(document.querySelector(".perspective-float-window")).toBeFalsy();
+    expect(floatWindow.style.display).toBe("none");
 
     handle.unmount();
   });
 
-  it("close button in float window closes it", () => {
+  it("close button in float window hides it", () => {
     const onClose = vi.fn();
     const handle = createFloatBubble({
       researchId: "test-research-id",
@@ -199,8 +263,11 @@ describe("createFloatBubble", () => {
 
     closeBtn.click();
 
+    const floatWindow = document.querySelector(
+      ".perspective-float-window"
+    ) as HTMLElement;
     expect(handle.isOpen).toBe(false);
-    expect(document.querySelector(".perspective-float-window")).toBeFalsy();
+    expect(floatWindow.style.display).toBe("none");
     expect(onClose).toHaveBeenCalled();
   });
 
@@ -223,6 +290,18 @@ describe("createFloatBubble", () => {
         type: "float",
       })
     ).toBe(true);
+  });
+
+  it("unmount removes the hidden float window when float was never opened", () => {
+    const handle = createFloatBubble({
+      researchId: "test-research-id",
+    });
+
+    expect(document.querySelector(".perspective-float-window")).toBeTruthy();
+
+    handle.unmount();
+
+    expect(document.querySelector(".perspective-float-window")).toBeFalsy();
   });
 
   it("destroy clears persisted open state", () => {
@@ -408,7 +487,7 @@ describe("createFloatBubble", () => {
       handle.unmount();
     });
 
-    it("close prevents further callback invocations from that window", () => {
+    it("callbacks are gated while float is hidden", () => {
       const onSubmit = vi.fn();
       const onClose = vi.fn();
 
@@ -425,9 +504,106 @@ describe("createFloatBubble", () => {
       handle.close();
       expect(onClose).toHaveBeenCalledTimes(1);
 
+      // Iframe is still alive but hidden — callbacks should not fire
       sendMessage(iframe, "perspective:submit");
-
       expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate parent page while float is hidden", () => {
+      const originalHref = window.location.href;
+      const mockLocation = { href: originalHref };
+
+      Object.defineProperty(window, "location", {
+        value: mockLocation,
+        writable: true,
+        configurable: true,
+      });
+
+      const handle = createFloatBubble({
+        researchId,
+        host,
+      });
+
+      handle.open();
+      const iframe = handle.iframe!;
+      handle.close();
+
+      sendMessage(iframe, "perspective:redirect", {
+        url: "https://example.com/hidden-float",
+      });
+
+      expect(mockLocation.href).toBe(originalHref);
+
+      handle.unmount();
+
+      Object.defineProperty(window, "location", {
+        value: { href: originalHref },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("fires onClose when unmounted while open", () => {
+      const onClose = vi.fn();
+      const handle = createFloatBubble({
+        researchId,
+        host,
+        onClose,
+      });
+
+      handle.open();
+      handle.unmount();
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("preloaded iframe callback replay", () => {
+    const host = "https://getperspective.ai";
+    const researchId = "test-research-id";
+
+    const simulateReady = (iframe: HTMLIFrameElement) => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "perspective:ready", researchId },
+          origin: host,
+          source: iframe.contentWindow,
+        })
+      );
+    };
+
+    it("fires onReady immediately when claiming a ready preloaded iframe", () => {
+      const onReady = vi.fn();
+
+      preloadIframe(researchId, "float", host);
+
+      const preloadedIframe = document.querySelector(
+        "iframe[data-perspective-preload]"
+      ) as HTMLIFrameElement;
+
+      simulateReady(preloadedIframe);
+
+      const handle = createFloatBubble({ researchId, host, onReady });
+
+      expect(onReady).toHaveBeenCalledTimes(1);
+      expect(handle.iframe).toBe(preloadedIframe);
+
+      handle.unmount();
+    });
+
+    it("waits for onReady when the claimed preloaded iframe is not ready yet", () => {
+      const onReady = vi.fn();
+
+      preloadIframe(researchId, "float", host);
+
+      const handle = createFloatBubble({ researchId, host, onReady });
+
+      expect(onReady).not.toHaveBeenCalled();
+
+      simulateReady(handle.iframe!);
+      expect(onReady).toHaveBeenCalledTimes(1);
+
+      handle.unmount();
     });
   });
 
@@ -467,7 +643,7 @@ describe("createFloatBubble", () => {
     });
 
     it("icon 'avatar' renders <img> when avatarUrl is available", () => {
-      const handle = createFloatBubble({
+      const config: FloatBubbleConfig = {
         researchId: "test-research-id",
         launcher: { icon: "avatar" },
         _themeConfig: {
@@ -477,7 +653,8 @@ describe("createFloatBubble", () => {
           darkTextColor: "#ffffff",
           avatarUrl: "https://example.com/avatar.png",
         },
-      } as any);
+      };
+      const handle = createFloatBubble(config);
 
       const bubble = document.querySelector(
         ".perspective-float-bubble"
@@ -494,7 +671,7 @@ describe("createFloatBubble", () => {
     });
 
     it("icon 'avatar' falls back to default SVG when no avatarUrl", () => {
-      const handle = createFloatBubble({
+      const config: FloatBubbleConfig = {
         researchId: "test-research-id",
         launcher: { icon: "avatar" },
         _themeConfig: {
@@ -504,7 +681,8 @@ describe("createFloatBubble", () => {
           darkTextColor: "#ffffff",
           avatarUrl: null,
         },
-      } as any);
+      };
+      const handle = createFloatBubble(config);
 
       const bubble = document.querySelector(
         ".perspective-float-bubble"

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -11,13 +11,10 @@ import type {
   ThemeConfig,
 } from "./types";
 import { hasDom, getHost } from "./config";
-import {
-  createIframe,
-  setupMessageListener,
-  registerIframe,
-  ensureGlobalListeners,
-} from "./iframe";
-import { createLoadingIndicator } from "./loading";
+import { ensureGlobalListeners } from "./iframe";
+import { destroyPreloadedByType } from "./preload";
+import { removeTimer } from "./timing";
+import { createEmbedFrameSession } from "./frame-session";
 import { injectStyles, MIC_ICON, MESSAGES_ICON, CLOSE_ICON } from "./styles";
 import { getPersistedOpenState, setPersistedOpenState } from "./state";
 import { cn, getThemeClass, resolveIsDark } from "./utils";
@@ -123,6 +120,32 @@ function applyBubbleIcon(bubble: HTMLButtonElement, config: FloatConfig): void {
   bubble.innerHTML = fallbackHtml;
 }
 
+function applyBubbleThemeStyles(
+  bubble: HTMLButtonElement,
+  config: FloatConfig
+): void {
+  if (config.launcher?.style?.backgroundColor) {
+    return;
+  }
+
+  const bg = resolveIsDark(config.theme)
+    ? (config.brand?.dark?.primary ??
+      config._themeConfig?.darkPrimaryColor ??
+      "#a78bfa")
+    : (config.brand?.light?.primary ??
+      config._themeConfig?.primaryColor ??
+      "#7c3aed");
+
+  bubble.style.setProperty("--perspective-float-bg", bg);
+  bubble.style.setProperty("--perspective-float-shadow", `0 4px 12px ${bg}66`);
+  bubble.style.setProperty(
+    "--perspective-float-shadow-hover",
+    `0 6px 16px ${bg}80`
+  );
+  bubble.style.backgroundColor = bg;
+  bubble.style.boxShadow = `0 4px 12px ${bg}66`;
+}
+
 function createChimeSound(audioCtx: AudioContext): void {
   const t = audioCtx.currentTime;
 
@@ -168,7 +191,7 @@ function createNoOpHandle(researchId: string): FloatHandle {
 }
 
 export function createFloatBubble(config: FloatConfig): FloatHandle {
-  const { researchId, _themeConfig, theme, brand } = config;
+  const { researchId, _themeConfig, brand } = config;
 
   // SSR safety: return no-op handle
   if (!hasDom()) {
@@ -191,21 +214,7 @@ export function createFloatBubble(config: FloatConfig): FloatHandle {
 
   // Apply theme color if available
   if (_themeConfig || brand) {
-    const isDark = resolveIsDark(theme);
-    const bg = isDark
-      ? (brand?.dark?.primary ?? _themeConfig?.darkPrimaryColor ?? "#a78bfa")
-      : (brand?.light?.primary ?? _themeConfig?.primaryColor ?? "#7c3aed");
-    bubble.style.setProperty("--perspective-float-bg", bg);
-    bubble.style.setProperty(
-      "--perspective-float-shadow",
-      `0 4px 12px ${bg}66`
-    );
-    bubble.style.setProperty(
-      "--perspective-float-shadow-hover",
-      `0 6px 16px ${bg}80`
-    );
-    bubble.style.backgroundColor = bg;
-    bubble.style.boxShadow = `0 4px 12px ${bg}66`;
+    applyBubbleThemeStyles(bubble, config);
   }
 
   // Apply launcher style overrides (highest precedence)
@@ -246,8 +255,8 @@ export function createFloatBubble(config: FloatConfig): FloatHandle {
   let floatWindow: HTMLElement | null = null;
   let iframe: HTMLIFrameElement | null = null;
   let cleanup: (() => void) | null = null;
-  let unregisterIframe: (() => void) | null = null;
   let isOpen = false;
+  let closeBtn: HTMLButtonElement | null = null;
   let teaser: HTMLElement | null = null;
   let teaserTypewriter: number | null = null;
   let notificationDot: HTMLElement | null = null;
@@ -398,87 +407,54 @@ export function createFloatBubble(config: FloatConfig): FloatHandle {
     welcomeTimers.push(soundTimer, teaserTimer);
   };
 
+  const mountFloatWindow = () => {
+    if (floatWindow && iframe) return;
+
+    floatWindow = document.createElement("div");
+    floatWindow.className = cn(
+      "perspective-float-window perspective-embed-root",
+      getThemeClass(currentConfig.theme)
+    );
+    floatWindow.style.display = "none";
+
+    closeBtn = document.createElement("button");
+    closeBtn.className = "perspective-close";
+    closeBtn.innerHTML = CLOSE_ICON;
+    closeBtn.setAttribute("aria-label", "Close chat");
+    closeBtn.addEventListener("click", handleFloatCloseButtonClick);
+
+    floatWindow.appendChild(closeBtn);
+    document.body.appendChild(floatWindow);
+
+    const frameSession = createEmbedFrameSession({
+      config,
+      type: "float",
+      host,
+      contentParent: floatWindow,
+      getConfig: () => currentConfig,
+      isOpen: () => isOpen,
+      onClose: closeFloat,
+      loadingStyle: (loading) => {
+        loading.style.borderRadius = "16px";
+      },
+    });
+
+    iframe = frameSession.iframe;
+    cleanup = frameSession.cleanup;
+  };
+
+  const handleFloatCloseButtonClick = () => {
+    closeFloat();
+  };
+
   const openFloat = () => {
     if (isOpen) return;
     isOpen = true;
     persistOpenState(true);
     clearWelcomeTimers();
     removeTeaser();
-
-    // Create float window
-    floatWindow = document.createElement("div");
-    floatWindow.className = cn(
-      "perspective-float-window perspective-embed-root",
-      getThemeClass(currentConfig.theme)
-    );
-
-    // Create close button
-    const closeBtn = document.createElement("button");
-    closeBtn.className = "perspective-close";
-    closeBtn.innerHTML = CLOSE_ICON;
-    closeBtn.setAttribute("aria-label", "Close chat");
-    closeBtn.addEventListener("click", () => closeFloat());
-
-    // Create loading indicator with theme and brand colors
-    const loading = createLoadingIndicator({
-      theme: currentConfig.theme,
-      brand: currentConfig.brand,
-    });
-    loading.style.borderRadius = "16px";
-
-    // Create iframe (hidden initially)
-    iframe = createIframe(
-      researchId,
-      "float",
-      host,
-      currentConfig.params,
-      currentConfig.brand,
-      currentConfig.theme
-    );
-    iframe.style.opacity = "0";
-    iframe.style.transition = "opacity 0.3s ease";
-
-    floatWindow.appendChild(closeBtn);
-    floatWindow.appendChild(loading);
-    floatWindow.appendChild(iframe);
-    document.body.appendChild(floatWindow);
-
-    // Set up message listener with loading state handling
-    cleanup = setupMessageListener(
-      researchId,
-      {
-        get onReady() {
-          return () => {
-            loading.style.opacity = "0";
-            iframe!.style.opacity = "1";
-            setTimeout(() => loading.remove(), 300);
-            currentConfig.onReady?.();
-          };
-        },
-        get onSubmit() {
-          return currentConfig.onSubmit;
-        },
-        get onNavigate() {
-          return currentConfig.onNavigate;
-        },
-        get onClose() {
-          return closeFloat;
-        },
-        get onError() {
-          return currentConfig.onError;
-        },
-      },
-      iframe,
-      host,
-      { skipResize: true, hasCloseButton: true }
-    );
-
-    // Register iframe for theme change notifications
-    if (iframe) {
-      unregisterIframe = registerIframe(iframe, host);
-    }
-
-    // Update bubble icon to close
+    mountFloatWindow();
+    floatWindow!.style.display = "";
     setBubbleOpenState();
   };
 
@@ -489,36 +465,42 @@ export function createFloatBubble(config: FloatConfig): FloatHandle {
     }
     isOpen = false;
 
-    cleanup?.();
-    unregisterIframe?.();
-    floatWindow?.remove();
-    floatWindow = null;
-    iframe = null;
-    cleanup = null;
-    unregisterIframe = null;
-
-    // Restore bubble icon
+    floatWindow!.style.display = "none";
     setBubbleClosedState();
 
     currentConfig.onClose?.();
   };
-
   // Toggle on bubble click
-  bubble.addEventListener("click", () => {
+  const bubbleClickHandler = () => {
     if (isOpen) {
       closeFloat();
     } else {
       openFloat();
     }
-  });
+  };
+  bubble.addEventListener("click", bubbleClickHandler);
 
+  // Build the float shell eagerly so first open only flips visibility.
+  mountFloatWindow();
   const unmount = () => {
+    const wasOpen = isOpen;
+    isOpen = false;
     clearWelcomeTimers();
     removeTeaser();
-    closeFloat({ persistState: false });
+    closeBtn?.removeEventListener("click", handleFloatCloseButtonClick);
+    bubble.removeEventListener("click", bubbleClickHandler);
+    cleanup?.();
+    destroyPreloadedByType(researchId, "float");
+    floatWindow?.remove();
+    closeBtn = null;
+    floatWindow = null;
+    iframe = null;
+    cleanup = null;
     bubble.remove();
     void audioCtx?.close();
     audioCtx = null;
+    removeTimer(researchId);
+    if (wasOpen) currentConfig.onClose?.();
   };
 
   const destroy = () => {
@@ -541,6 +523,9 @@ export function createFloatBubble(config: FloatConfig): FloatHandle {
       }
     ) => {
       currentConfig = { ...currentConfig, ...options };
+      if (currentConfig._themeConfig || currentConfig.brand) {
+        applyBubbleThemeStyles(bubble, currentConfig);
+      }
       if (!isOpen) {
         setBubbleClosedState();
       }

--- a/packages/sdk/src/frame-session.ts
+++ b/packages/sdk/src/frame-session.ts
@@ -1,0 +1,157 @@
+import type { EmbedConfig, EmbedType } from "./types";
+import {
+  createIframe,
+  setupMessageListener,
+  sendMessage,
+  registerIframe,
+  getCachedAuthToken,
+  ensureGlobalListeners,
+} from "./iframe";
+import { createLoadingIndicator } from "./loading";
+import { claimPreloadedIframe } from "./preload";
+import { getReusableEmbedSignature } from "./reuse";
+import { MESSAGE_TYPES, SDK_VERSION, CURRENT_FEATURES } from "./constants";
+
+const noopNavigate = () => {};
+
+type SessionEmbedType = Extract<EmbedType, "popup" | "slider" | "float">;
+
+export interface EmbedFrameSession {
+  iframe: HTMLIFrameElement;
+  cleanup: () => void;
+  replayOpenCallbacks: () => void;
+  reuseSignature: string;
+}
+
+export function createEmbedFrameSession(options: {
+  config: EmbedConfig;
+  type: SessionEmbedType;
+  host: string;
+  contentParent: HTMLElement;
+  getConfig: () => EmbedConfig;
+  isOpen: () => boolean;
+  onClose: () => void;
+  loadingStyle?: (loading: HTMLElement) => void;
+  hasCloseButton?: boolean;
+}): EmbedFrameSession {
+  const { config, type, host, contentParent, getConfig, isOpen, onClose } =
+    options;
+  const { researchId } = config;
+  ensureGlobalListeners();
+  const reuseSignature = getReusableEmbedSignature(config);
+  const claimed = claimPreloadedIframe(researchId, type, reuseSignature);
+  const iframe =
+    claimed?.iframe ??
+    createIframe(
+      researchId,
+      type,
+      host,
+      config.params,
+      config.brand,
+      config.theme
+    );
+
+  let loading: HTMLElement | null = null;
+  if (!claimed?.wasReady) {
+    loading = createLoadingIndicator({
+      theme: config.theme,
+      brand: config.brand,
+    });
+    options.loadingStyle?.(loading);
+  }
+
+  iframe.style.border = "none";
+  if (claimed?.wasReady) {
+    iframe.style.opacity = "1";
+  } else {
+    iframe.style.opacity = "0";
+    iframe.style.transition = "opacity 0.3s ease";
+  }
+
+  if (loading) {
+    contentParent.appendChild(loading);
+  }
+  contentParent.appendChild(iframe);
+
+  let isReady = Boolean(claimed?.wasReady);
+  let lastAuthToken = getCachedAuthToken(researchId);
+
+  const replayOpenCallbacks = () => {
+    if (!isReady) return;
+
+    const currentConfig = getConfig();
+    currentConfig.onReady?.();
+    const cachedToken = lastAuthToken ?? getCachedAuthToken(researchId);
+    if (cachedToken) {
+      currentConfig.onAuth?.({ researchId, token: cachedToken });
+    }
+  };
+
+  const cleanupMessageListener = setupMessageListener(
+    researchId,
+    {
+      get onReady() {
+        return () => {
+          isReady = true;
+          if (loading) {
+            loading.style.opacity = "0";
+            iframe.style.opacity = "1";
+            const element = loading;
+            setTimeout(() => element.remove(), 300);
+            loading = null;
+          }
+          getConfig().onReady?.();
+        };
+      },
+      get onSubmit() {
+        return isOpen() ? getConfig().onSubmit : undefined;
+      },
+      get onNavigate() {
+        return isOpen() ? getConfig().onNavigate : noopNavigate;
+      },
+      get onClose() {
+        return onClose;
+      },
+      get onAuth() {
+        return ({ token }: { researchId: string; token: string }) => {
+          lastAuthToken = token;
+          getConfig().onAuth?.({ researchId, token });
+        };
+      },
+      get onError() {
+        return isOpen() ? getConfig().onError : undefined;
+      },
+    },
+    iframe,
+    host,
+    {
+      skipResize: true,
+      hasCloseButton: options.hasCloseButton ?? true,
+      isActive: isOpen,
+    }
+  );
+
+  const unregisterIframe = registerIframe(iframe, host);
+
+  if (claimed?.wasReady) {
+    // Re-send init with correct hasCloseButton — preload sent it with false
+    sendMessage(iframe, host, {
+      type: MESSAGE_TYPES.init,
+      version: SDK_VERSION,
+      features: CURRENT_FEATURES,
+      researchId,
+      hasCloseButton: options.hasCloseButton ?? true,
+    });
+    replayOpenCallbacks();
+  }
+
+  return {
+    iframe,
+    cleanup: () => {
+      cleanupMessageListener();
+      unregisterIframe();
+    },
+    replayOpenCallbacks,
+    reuseSignature,
+  };
+}

--- a/packages/sdk/src/fullpage.test.ts
+++ b/packages/sdk/src/fullpage.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createFullpage } from "./fullpage";
 import * as config from "./config";
+import { MESSAGE_TYPES } from "./constants";
+import * as timing from "./timing";
 
 describe("createFullpage", () => {
   beforeEach(() => {
@@ -36,6 +38,18 @@ describe("createFullpage", () => {
     handle.unmount();
   });
 
+  it("removes the load timer on unmount", () => {
+    const removeTimerSpy = vi.spyOn(timing, "removeTimer");
+
+    const handle = createFullpage({
+      researchId: "test-research-id",
+    });
+
+    handle.unmount();
+
+    expect(removeTimerSpy).toHaveBeenCalledWith("test-research-id");
+  });
+
   it("returns no-op handle when no DOM", () => {
     vi.spyOn(config, "hasDom").mockReturnValue(false);
 
@@ -61,7 +75,7 @@ describe("createFullpage", () => {
     expect(document.querySelector(".perspective-fullpage")).toBeFalsy();
   });
 
-  it("destroy is alias for unmount", () => {
+  it("destroy removes the fullpage container", () => {
     const handle = createFullpage({
       researchId: "test-research-id",
     });
@@ -73,7 +87,7 @@ describe("createFullpage", () => {
     expect(document.querySelector(".perspective-fullpage")).toBeFalsy();
   });
 
-  it("calls onClose on unmount", () => {
+  it("does not call onClose on unmount", () => {
     const onClose = vi.fn();
     const handle = createFullpage({
       researchId: "test-research-id",
@@ -82,7 +96,19 @@ describe("createFullpage", () => {
 
     handle.unmount();
 
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose on destroy", () => {
+    const onClose = vi.fn();
+    const handle = createFullpage({
+      researchId: "test-research-id",
+      onClose,
+    });
+
+    handle.destroy();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("applies theme class", () => {
@@ -175,6 +201,41 @@ describe("createFullpage", () => {
       handle.unmount();
     });
 
+    it("forwards auth-complete messages to onAuth", () => {
+      const onAuth = vi.fn();
+      const popupWindow = {} as Window;
+      vi.spyOn(window, "open").mockReturnValue(popupWindow);
+
+      const handle = createFullpage({
+        researchId,
+        host,
+        onAuth,
+      });
+
+      sendMessage(handle.iframe!, MESSAGE_TYPES.authRequest, {
+        provider: "google",
+        authUrl: `${host}/embed-auth/google`,
+      });
+
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: MESSAGE_TYPES.popupAuthComplete,
+            token: "test-token",
+          },
+          origin: host,
+          source: popupWindow,
+        })
+      );
+
+      expect(onAuth).toHaveBeenCalledWith({
+        researchId,
+        token: "test-token",
+      });
+
+      handle.unmount();
+    });
+
     it("sequential updates only use latest callback", () => {
       const fn1 = vi.fn();
       const fn2 = vi.fn();
@@ -211,13 +272,28 @@ describe("createFullpage", () => {
 
       const iframe = handle.iframe!;
 
-      handle.unmount();
+      handle.destroy();
       expect(onClose).toHaveBeenCalledTimes(1);
 
       sendMessage(iframe, "perspective:submit");
       sendMessage(iframe, "perspective:close");
 
       expect(onSubmit).not.toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("close messages tear down the embed and fire onClose once", () => {
+      const onClose = vi.fn();
+
+      const handle = createFullpage({
+        researchId,
+        host,
+        onClose,
+      });
+
+      sendMessage(handle.iframe!, "perspective:close");
+
+      expect(document.querySelector(".perspective-fullpage")).toBeFalsy();
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -13,6 +13,7 @@ import {
 } from "./iframe";
 import { createLoadingIndicator } from "./loading";
 import { injectStyles } from "./styles";
+import { removeTimer } from "./timing";
 import { cn, getThemeClass } from "./utils";
 
 function createNoOpHandle(researchId: string): EmbedHandle {
@@ -71,16 +72,26 @@ export function createFullpage(config: EmbedConfig): EmbedHandle {
   // Mutable config reference for updates
   let currentConfig = { ...config };
   let messageCleanup: (() => void) | null = null;
+  let destroyed = false;
 
   // Register iframe for theme change notifications
   const unregisterIframe = registerIframe(iframe, host);
 
-  const unmount = () => {
+  const teardown = (notifyClose: boolean) => {
+    if (destroyed) return;
+    destroyed = true;
+
     messageCleanup?.();
+    messageCleanup = null;
     unregisterIframe();
+    removeTimer(researchId);
     container.remove();
-    currentConfig.onClose?.();
+    if (notifyClose) {
+      currentConfig.onClose?.();
+    }
   };
+  const unmount = () => teardown(false);
+  const destroy = () => teardown(true);
 
   // Set up message listener
   messageCleanup = setupMessageListener(
@@ -101,10 +112,13 @@ export function createFullpage(config: EmbedConfig): EmbedHandle {
         return currentConfig.onNavigate;
       },
       get onClose() {
-        return unmount;
+        return destroy;
       },
       get onError() {
         return currentConfig.onError;
+      },
+      get onAuth() {
+        return currentConfig.onAuth;
       },
     },
     iframe,
@@ -117,7 +131,7 @@ export function createFullpage(config: EmbedConfig): EmbedHandle {
     update: (options) => {
       currentConfig = { ...currentConfig, ...options };
     },
-    destroy: unmount,
+    destroy,
     researchId,
     type: "fullpage" as const,
     iframe,

--- a/packages/sdk/src/hints.test.ts
+++ b/packages/sdk/src/hints.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { injectResourceHints } from "./hints";
+
+describe("injectResourceHints", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+  });
+  afterEach(() => {
+    document.head.innerHTML = "";
+  });
+
+  it("injects preconnect and dns-prefetch links", () => {
+    injectResourceHints("https://getperspective.ai");
+
+    const preconnect = document.querySelector(
+      'link[rel="preconnect"][href="https://getperspective.ai"]'
+    );
+    const dnsPrefetch = document.querySelector(
+      'link[rel="dns-prefetch"][href="https://getperspective.ai"]'
+    );
+
+    expect(preconnect).not.toBeNull();
+    expect(preconnect?.getAttribute("crossorigin")).toBe("");
+    expect(dnsPrefetch).not.toBeNull();
+  });
+
+  it("is idempotent", () => {
+    injectResourceHints("https://getperspective.ai");
+    injectResourceHints("https://getperspective.ai");
+
+    const links = document.querySelectorAll(
+      'link[rel="preconnect"][href="https://getperspective.ai"]'
+    );
+    expect(links.length).toBe(1);
+  });
+});

--- a/packages/sdk/src/hints.ts
+++ b/packages/sdk/src/hints.ts
@@ -1,0 +1,33 @@
+/**
+ * Resource hint injection for faster iframe loading
+ * SSR-safe - all DOM access is guarded
+ */
+
+import { hasDom } from "./config";
+
+/** Inject preconnect and dns-prefetch hints for the embed host */
+export function injectResourceHints(host: string): void {
+  if (!hasDom()) return;
+
+  let origin: string;
+  try {
+    origin = new URL(host).origin;
+  } catch {
+    return;
+  }
+
+  if (!document.querySelector(`link[rel="preconnect"][href="${origin}"]`)) {
+    const preconnect = document.createElement("link");
+    preconnect.rel = "preconnect";
+    preconnect.href = origin;
+    preconnect.crossOrigin = "";
+    document.head.appendChild(preconnect);
+  }
+
+  if (!document.querySelector(`link[rel="dns-prefetch"][href="${origin}"]`)) {
+    const dnsPrefetch = document.createElement("link");
+    dnsPrefetch.rel = "dns-prefetch";
+    dnsPrefetch.href = origin;
+    document.head.appendChild(dnsPrefetch);
+  }
+}

--- a/packages/sdk/src/iframe-auth.test.ts
+++ b/packages/sdk/src/iframe-auth.test.ts
@@ -72,6 +72,44 @@ describe("embed auth message handling", () => {
       expect(openSpy.mock.calls[1]![1]).toBe("_blank");
     });
 
+    it("notifies the host app when auth windows are blocked entirely", () => {
+      const onError = vi.fn();
+      const postMessageSpy = vi.fn();
+      vi.spyOn(window, "open").mockReturnValue(null);
+      Object.defineProperty(iframe, "contentWindow", {
+        value: { postMessage: postMessageSpy },
+        configurable: true,
+      });
+
+      removeListener = setupMessageListener(
+        researchId,
+        { onError },
+        iframe,
+        host
+      );
+
+      dispatchFromIframe({
+        type: MESSAGE_TYPES.authRequest,
+        provider: "google",
+        authUrl: "https://getperspective.ai/embed-auth/google?research_id=test",
+      });
+
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: "UNKNOWN",
+          message:
+            "Authentication popup was blocked. Please allow popups and try again.",
+        })
+      );
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MESSAGE_TYPES.authCancelled,
+          researchId,
+        }),
+        host
+      );
+    });
+
     it("ignores auth request without authUrl", () => {
       const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
       removeListener = setupMessageListener(researchId, {}, iframe, host);
@@ -98,7 +136,7 @@ describe("embed auth message handling", () => {
     });
 
     it("listens for postMessage from popup after opening auth window", () => {
-      vi.spyOn(window, "open").mockReturnValue(null);
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as Window);
       const addEventSpy = vi.spyOn(window, "addEventListener");
       removeListener = setupMessageListener(researchId, {}, iframe, host);
 
@@ -259,6 +297,34 @@ describe("embed auth message handling", () => {
       });
     });
 
+    it("relays cached token when expiresAt is encoded in seconds", () => {
+      const token = createMockToken(
+        researchId,
+        Math.floor((Date.now() + 86400000) / 1000)
+      );
+      localStorage.setItem(
+        `${STORAGE_KEYS.embedAuthToken}:${researchId}`,
+        token
+      );
+
+      const postMessageSpy = vi.fn();
+      Object.defineProperty(iframe, "contentWindow", {
+        value: { postMessage: postMessageSpy },
+        configurable: true,
+      });
+
+      removeListener = setupMessageListener(researchId, {}, iframe, host);
+
+      dispatchFromIframe({ type: MESSAGE_TYPES.ready });
+
+      const authMessages = postMessageSpy.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as Record<string, unknown>).type ===
+          MESSAGE_TYPES.authComplete
+      );
+      expect(authMessages).toHaveLength(1);
+    });
+
     it("does NOT relay expired token on ready", () => {
       // Pre-cache an expired token
       const expiredToken = createMockToken(researchId, Date.now() - 1000);
@@ -390,7 +456,7 @@ describe("embed auth message handling", () => {
 
   describe("auth listener cleanup on embed destroy", () => {
     it("cleans up auth listeners when removeListener is called during active auth", () => {
-      vi.spyOn(window, "open").mockReturnValue(null);
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as Window);
       const removeEventSpy = vi.spyOn(window, "removeEventListener");
       const clearIntervalSpy = vi.spyOn(window, "clearInterval");
 
@@ -412,7 +478,7 @@ describe("embed auth message handling", () => {
     });
 
     it("cleans up previous auth flow when new auth request arrives", () => {
-      vi.spyOn(window, "open").mockReturnValue(null);
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as Window);
       const clearIntervalSpy = vi.spyOn(window, "clearInterval");
 
       removeListener = setupMessageListener(researchId, {}, iframe, host);

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -6,8 +6,10 @@
 import type {
   BrandColors,
   EmbedConfig,
+  EmbedError,
   EmbedMessage,
   EmbedType,
+  ErrorCode,
 } from "./types";
 import { hasDom } from "./config";
 import {
@@ -23,6 +25,9 @@ import {
   ERROR_CODES,
 } from "./constants";
 import { normalizeHex } from "./utils";
+import { getTimer } from "./timing";
+
+const ERROR_CODE_VALUES: readonly string[] = Object.values(ERROR_CODES);
 
 /** Validate redirect URL - allow https, http localhost, and relative URLs */
 function isAllowedRedirectUrl(url: string): boolean {
@@ -89,10 +94,25 @@ function decodeTokenExpiry(token: string): number | null {
     if (parts.length !== 3) return null;
     const base64 = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
     const payload = JSON.parse(atob(base64));
-    return payload.data?.expiresAt ?? null;
+    const expiresAt = payload.data?.expiresAt;
+    if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) {
+      return null;
+    }
+    return expiresAt < 1_000_000_000_000 ? expiresAt * 1000 : expiresAt;
   } catch {
     return null;
   }
+}
+
+function createEmbedError(
+  message: string,
+  code: ErrorCode = ERROR_CODES.UNKNOWN
+): EmbedError {
+  return Object.assign(new Error(message), { code });
+}
+
+function isErrorCode(value: unknown): value is ErrorCode {
+  return typeof value === "string" && ERROR_CODE_VALUES.includes(value);
 }
 
 function authTokenKey(researchId: string): string {
@@ -102,7 +122,7 @@ function authTokenKey(researchId: string): string {
 /** Get cached embed auth token from parent's first-party localStorage (Layer 2).
  * Called on iframe ready to relay token back — critical for Safari where
  * iframe localStorage (Layer 1) is wiped on tab close. */
-function getCachedAuthToken(researchId: string): string | null {
+export function getCachedAuthToken(researchId: string): string | null {
   if (!hasDom()) return null;
   try {
     const key = authTokenKey(researchId);
@@ -276,6 +296,16 @@ export function createIframe(
   iframe.setAttribute("data-perspective", "true");
   iframe.style.cssText = "border:none;";
 
+  iframe.addEventListener(
+    "load",
+    () => {
+      getTimer(researchId).mark("iframe:loaded");
+    },
+    { once: true }
+  );
+
+  getTimer(researchId).mark("iframe:created");
+
   return iframe;
 }
 
@@ -284,7 +314,14 @@ export function setupMessageListener(
   config: Partial<EmbedConfig>,
   iframe: HTMLIFrameElement,
   host: string,
-  options?: { skipResize?: boolean; hasCloseButton?: boolean }
+  options?: {
+    skipResize?: boolean;
+    hasCloseButton?: boolean;
+    /** When true, only handle ready/resize — suppress redirect, auth, and close side effects. Used during preload. */
+    preloadOnly?: boolean;
+    /** When provided, suppress authRequest/authSignout side effects when this returns false. */
+    isActive?: () => boolean;
+  }
 ): () => void {
   if (!hasDom()) {
     return () => {};
@@ -307,6 +344,8 @@ export function setupMessageListener(
 
     switch (event.data.type) {
       case MESSAGE_TYPES.ready: {
+        getTimer(researchId).mark("perspective:ready");
+        getTimer(researchId).log();
         // Send scrollbar styles when iframe is ready
         sendScrollbarStyles(iframe, host);
         // Send anon_id for anonymous auth
@@ -347,20 +386,23 @@ export function setupMessageListener(
         }
         break;
 
+      // In preload mode, only ready and resize are handled — suppress all side effects
       case MESSAGE_TYPES.submit:
+        if (options?.preloadOnly) break;
         config.onSubmit?.({ researchId });
         break;
 
       case MESSAGE_TYPES.close:
+        if (options?.preloadOnly) break;
         config.onClose?.();
         break;
 
       case MESSAGE_TYPES.error: {
-        const error = new Error(
-          event.data.error
-        ) as import("./types").EmbedError;
-        error.code =
-          (event.data.code as import("./types").ErrorCode) || "UNKNOWN";
+        if (options?.preloadOnly) break;
+        const error = createEmbedError(
+          event.data.error,
+          isErrorCode(event.data.code) ? event.data.code : ERROR_CODES.UNKNOWN
+        );
 
         // Always log critical errors to console
         if (error.code === ERROR_CODES.SDK_OUTDATED) {
@@ -377,6 +419,7 @@ export function setupMessageListener(
       }
 
       case MESSAGE_TYPES.redirect: {
+        if (options?.preloadOnly) break;
         const redirectUrl = event.data.url;
         // Security: Only allow http(s) and localhost URLs
         if (!isAllowedRedirectUrl(redirectUrl)) {
@@ -396,6 +439,8 @@ export function setupMessageListener(
       }
 
       case MESSAGE_TYPES.authRequest: {
+        if (options?.preloadOnly) break;
+        if (options?.isActive && !options.isActive()) break;
         // The iframe can't do OAuth itself (cross-origin context, third-party
         // cookie blocking). So the iframe asks the SDK to open auth in a
         // first-party popup where cookies work normally. After auth, the
@@ -437,6 +482,19 @@ export function setupMessageListener(
         const authWindow =
           window.open(fullAuthUrl, "perspective-auth", popupFeatures) ??
           window.open(fullAuthUrl, "_blank"); // Popup blocked — fall back to new tab
+
+        if (!authWindow) {
+          sendMessage(iframe, host, {
+            type: MESSAGE_TYPES.authCancelled,
+            researchId,
+          });
+          config.onError?.(
+            createEmbedError(
+              "Authentication popup was blocked. Please allow popups and try again."
+            )
+          );
+          break;
+        }
 
         // Token handling: cache in Layer 2 (parent localStorage for persistence),
         // relay to iframe (which stores in Layer 1), and notify host app
@@ -492,6 +550,8 @@ export function setupMessageListener(
       }
 
       case MESSAGE_TYPES.authSignout: {
+        if (options?.preloadOnly) break;
+        if (options?.isActive && !options.isActive()) break;
         // User signed out in iframe — clear cached token so the next visit
         // requires re-authentication (no stale session)
         clearAuthToken(researchId);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -29,6 +29,9 @@ export { openSlider } from "./slider";
 export { createFloatBubble, createChatBubble } from "./float";
 export { createFullpage } from "./fullpage";
 
+// Auto-open helpers
+export { setupAutoOpenPopup } from "./auto-open";
+
 // Auto-open triggers
 export {
   setupTrigger,
@@ -39,8 +42,16 @@ export {
 } from "./triggers";
 
 // Configuration
-export { configure, getConfig } from "./config";
 export { getPersistedOpenState } from "./state";
+export { configure, getConfig, getHost } from "./config";
+
+// Preloading
+export {
+  preloadIframe,
+  destroyPreloaded,
+  destroyPreloadedByType,
+} from "./preload";
+export { stableSerialize } from "./reuse";
 
 // Types
 export type {
@@ -62,6 +73,7 @@ export type {
   LauncherConfig,
   LauncherIcon,
   LauncherStyle,
+  ErrorCode,
 } from "./types";
 
 // Re-export commonly used constants and types
@@ -72,8 +84,16 @@ export {
   DATA_ATTRS,
   PARAM_KEYS,
   BRAND_KEYS,
+  ERROR_CODES,
   MESSAGE_TYPES,
   THEME_VALUES,
+  MODE_VALUES,
 } from "./constants";
 
-export type { ThemeValue, ParamKey, BrandKey, MessageType } from "./constants";
+export type {
+  ThemeValue,
+  ParamKey,
+  BrandKey,
+  MessageType,
+  ModeValue,
+} from "./constants";

--- a/packages/sdk/src/loading.test.ts
+++ b/packages/sdk/src/loading.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createLoadingIndicator } from "./loading";
+
+describe("createLoadingIndicator", () => {
+  beforeEach(async () => {
+    // Clean up injected shimmer keyframes and reset module state
+    document.getElementById("perspective-shimmer-keyframes")?.remove();
+    // Re-import module to reset shimmerInjected flag
+    vi.resetModules();
+  });
+
+  it("returns an element with perspective-loading class", () => {
+    const el = createLoadingIndicator();
+    expect(el.className).toBe("perspective-loading");
+  });
+
+  it("renders skeleton card with 4 shimmer lines", () => {
+    const el = createLoadingIndicator();
+    const card = el.children[0] as HTMLElement;
+    expect(card).toBeTruthy();
+    expect(card.style.borderRadius).toBe("16px");
+    // Title + 3 body lines = 4 shimmer divs
+    expect(card.children).toHaveLength(4);
+  });
+
+  it("renders chat input area with button skeleton", () => {
+    const el = createLoadingIndicator();
+    const inputArea = el.children[1] as HTMLElement;
+    expect(inputArea).toBeTruthy();
+    expect(inputArea.style.borderRadius).toBe("28px");
+    const button = inputArea.children[0] as HTMLElement;
+    expect(button).toBeTruthy();
+    expect(button.style.borderRadius).toBe("9999px");
+  });
+
+  it("applies shimmer animation to skeleton lines", () => {
+    const el = createLoadingIndicator();
+    const card = el.children[0] as HTMLElement;
+    const firstLine = card.children[0] as HTMLElement;
+    expect(firstLine.style.animation).toContain("perspective-shimmer");
+  });
+
+  it("injects shimmer keyframes into document head", async () => {
+    const { createLoadingIndicator: create } = await import("./loading");
+    create();
+    const style = document.getElementById("perspective-shimmer-keyframes");
+    expect(style).toBeTruthy();
+    expect(style?.textContent).toContain("@keyframes perspective-shimmer");
+  });
+
+  it("injects shimmer keyframes only once across multiple calls", async () => {
+    const { createLoadingIndicator: create } = await import("./loading");
+    create();
+    create();
+    const styles = document.querySelectorAll("#perspective-shimmer-keyframes");
+    expect(styles).toHaveLength(1);
+  });
+
+  it("uses light theme colors by default", () => {
+    const el = createLoadingIndicator();
+    expect(el.style.background).toBe("#ffffff");
+  });
+
+  it("uses dark theme colors when specified", () => {
+    const el = createLoadingIndicator({ theme: "dark" });
+    expect(el.style.background).toBe("#02040a");
+  });
+
+  it("uses brand bg color when provided", () => {
+    const el = createLoadingIndicator({
+      theme: "light",
+      brand: { light: { primary: "#ff0000", bg: "#fef2f2" } },
+    });
+    expect(el.style.background).toBe("#fef2f2");
+  });
+
+  it("uses dark brand bg when dark theme", () => {
+    const el = createLoadingIndicator({
+      theme: "dark",
+      brand: { dark: { primary: "#ef4444", bg: "#1a0000" } },
+    });
+    expect(el.style.background).toBe("#1a0000");
+  });
+
+  it("falls back to default bg when brand has no bg", () => {
+    const el = createLoadingIndicator({
+      theme: "light",
+      brand: { light: { primary: "#ff0000" } },
+    });
+    expect(el.style.background).toBe("#ffffff");
+  });
+
+  it("container uses flex column layout", () => {
+    const el = createLoadingIndicator();
+    expect(el.style.display).toBe("flex");
+    expect(el.style.flexDirection).toBe("column");
+  });
+
+  it("is removable from DOM", () => {
+    const el = createLoadingIndicator();
+    document.body.appendChild(el);
+    expect(document.querySelector(".perspective-loading")).toBeTruthy();
+    el.remove();
+    expect(document.querySelector(".perspective-loading")).toBeFalsy();
+  });
+});

--- a/packages/sdk/src/loading.ts
+++ b/packages/sdk/src/loading.ts
@@ -1,53 +1,79 @@
 /**
- * Loading indicator for embed iframes
+ * Loading skeleton for embed iframes
+ *
+ * Shows a skeleton that matches the conversation UI layout (welcome card +
+ * input area) instead of a generic spinner. This makes the loading feel
+ * faster because it sets visual expectations.
+ *
  * SSR-safe - returns no-op on server
  */
 
 import type { BrandColors, ThemeValue } from "./types";
 import { hasDom } from "./config";
-import { resolveTheme, hexToRgba } from "./utils";
+import { resolveTheme } from "./utils";
 
 /** Default colors matching codebase theme */
 const DEFAULT_COLORS = {
   light: {
     bg: "#ffffff",
-    primary: "#7629C8",
+    shimmer: "#f3f4f6",
+    shimmerHighlight: "#e5e7eb",
+    border: "#f0f0f0",
   },
   dark: {
     bg: "#02040a",
-    primary: "#B170FF",
+    shimmer: "#1a1d23",
+    shimmerHighlight: "#2a2d33",
+    border: "#1a1d23",
   },
 };
 
 export interface LoadingOptions {
   /** Theme override: 'dark', 'light', or 'system' (uses system preference) */
   theme?: ThemeValue;
-  /** Brand colors - uses primary color for spinner */
+  /** Brand colors - uses bg color for skeleton background */
   brand?: {
     light?: BrandColors;
     dark?: BrandColors;
   };
 }
 
-/** Get colors for loading indicator based on theme and brand */
+/** Get colors for loading skeleton based on theme and brand */
 function getLoadingColors(options?: LoadingOptions): {
   bg: string;
-  primary: string;
+  shimmer: string;
+  shimmerHighlight: string;
+  border: string;
 } {
   const theme = resolveTheme(options?.theme);
   const isDark = theme === "dark";
 
-  // Get brand colors for current theme
   const brandColors = isDark ? options?.brand?.dark : options?.brand?.light;
+  const defaults = isDark ? DEFAULT_COLORS.dark : DEFAULT_COLORS.light;
 
   return {
-    bg:
-      brandColors?.bg ||
-      (isDark ? DEFAULT_COLORS.dark.bg : DEFAULT_COLORS.light.bg),
-    primary:
-      brandColors?.primary ||
-      (isDark ? DEFAULT_COLORS.dark.primary : DEFAULT_COLORS.light.primary),
+    bg: brandColors?.bg || defaults.bg,
+    shimmer: defaults.shimmer,
+    shimmerHighlight: defaults.shimmerHighlight,
+    border: defaults.border,
   };
+}
+
+/** Inject shimmer keyframes once globally (shared across all embed instances) */
+let shimmerInjected = false;
+function injectShimmerKeyframes(): void {
+  if (shimmerInjected || !hasDom()) return;
+  shimmerInjected = true;
+
+  const styleEl = document.createElement("style");
+  styleEl.id = "perspective-shimmer-keyframes";
+  styleEl.textContent = `
+    @keyframes perspective-shimmer {
+      0% { background-position: -400px 0; }
+      100% { background-position: 400px 0; }
+    }
+  `;
+  document.head.appendChild(styleEl);
 }
 
 export function createLoadingIndicator(options?: LoadingOptions): HTMLElement {
@@ -55,6 +81,8 @@ export function createLoadingIndicator(options?: LoadingOptions): HTMLElement {
   if (!hasDom()) {
     return { remove: () => {}, style: {} } as unknown as HTMLElement;
   }
+
+  injectShimmerKeyframes();
 
   const colors = getLoadingColors(options);
 
@@ -67,24 +95,61 @@ export function createLoadingIndicator(options?: LoadingOptions): HTMLElement {
     right: 0;
     bottom: 0;
     display: flex;
-    align-items: center;
-    justify-content: center;
+    flex-direction: column;
     background: ${colors.bg};
-    transition: opacity 0.3s ease;
+    transition: opacity 0.15s ease;
     z-index: 1;
+    overflow: hidden;
+    padding: 1.5rem;
+    box-sizing: border-box;
   `;
 
-  // Create spinner (keyframes defined in styles.ts)
-  const spinner = document.createElement("div");
-  spinner.style.cssText = `
-    width: 2.5rem;
-    height: 2.5rem;
-    border: 3px solid ${hexToRgba(colors.primary, 0.15)};
-    border-top-color: ${colors.primary};
-    border-radius: 50%;
-    animation: perspective-spin 0.8s linear infinite;
+  const shimmerBg = `linear-gradient(90deg, ${colors.shimmer} 25%, ${colors.shimmerHighlight} 50%, ${colors.shimmer} 75%)`;
+  const shimmer = (width: string, height: string): HTMLElement => {
+    const el = document.createElement("div");
+    el.style.cssText = `background:${shimmerBg};background-size:800px 100%;animation:perspective-shimmer 1.5s infinite linear;border-radius:8px;height:${height};width:${width};margin-bottom:0.5rem;`;
+    return el;
+  };
+
+  // Welcome card skeleton — matches the greeting card with rounded corners
+  const card = document.createElement("div");
+  card.style.cssText = `border:1px solid ${colors.border};border-radius:16px;padding:1.25rem;margin-bottom:auto;`;
+
+  // Title line (bold, wider)
+  const title = shimmer("55%", "1.25rem");
+  title.style.marginBottom = "0.875rem";
+  card.appendChild(title);
+
+  // Body lines (3 lines mimicking welcome message text)
+  card.appendChild(shimmer("92%", "0.75rem"));
+  card.appendChild(shimmer("88%", "0.75rem"));
+  const lastLine = shimmer("70%", "0.75rem");
+  lastLine.style.marginBottom = "0";
+  card.appendChild(lastLine);
+
+  container.appendChild(card);
+
+  // Chat input skeleton — matches rounded-[28px] input with pill button
+  const inputArea = document.createElement("div");
+  inputArea.style.cssText = `
+    margin-top: 1rem;
+    border: 1px solid ${colors.border};
+    border-radius: 28px;
+    height: 3rem;
+    padding: 0.375rem 0.375rem 0.375rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    box-sizing: border-box;
   `;
 
-  container.appendChild(spinner);
+  // Talk button pill skeleton
+  const buttonSkeleton = shimmer("4.5rem", "2.25rem");
+  buttonSkeleton.style.borderRadius = "9999px";
+  buttonSkeleton.style.marginBottom = "0";
+  inputArea.appendChild(buttonSkeleton);
+
+  container.appendChild(inputArea);
+
   return container;
 }

--- a/packages/sdk/src/popup.test.ts
+++ b/packages/sdk/src/popup.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { openPopup } from "./popup";
+import { preloadIframe, destroyPreloaded } from "./preload";
 import * as config from "./config";
 import { getPersistedOpenState } from "./state";
 
@@ -86,21 +87,9 @@ describe("openPopup", () => {
     ).toBe(false);
   });
 
-  it("calls onClose callback when destroyed", () => {
+  it("close button click hides popup and fires onClose", () => {
     const onClose = vi.fn();
     const handle = openPopup({
-      researchId: "test-research-id",
-      onClose,
-    });
-
-    handle.destroy();
-
-    expect(onClose).toHaveBeenCalled();
-  });
-
-  it("close button click closes popup", () => {
-    const onClose = vi.fn();
-    openPopup({
       researchId: "test-research-id",
       onClose,
     });
@@ -111,12 +100,20 @@ describe("openPopup", () => {
     closeBtn.click();
 
     expect(onClose).toHaveBeenCalled();
-    expect(document.querySelector(".perspective-overlay")).toBeFalsy();
+    // Overlay stays in DOM but is hidden
+    const overlay = document.querySelector(
+      ".perspective-overlay"
+    ) as HTMLElement;
+    expect(overlay).toBeTruthy();
+    expect(overlay.style.display).toBe("none");
+    expect(handle.isOpen).toBe(false);
+
+    handle.destroy();
   });
 
-  it("clicking overlay background closes popup", () => {
+  it("clicking overlay background hides popup", () => {
     const onClose = vi.fn();
-    openPopup({
+    const handle = openPopup({
       researchId: "test-research-id",
       onClose,
     });
@@ -127,7 +124,9 @@ describe("openPopup", () => {
     overlay.click();
 
     expect(onClose).toHaveBeenCalled();
-    expect(document.querySelector(".perspective-overlay")).toBeFalsy();
+    expect(overlay.style.display).toBe("none");
+
+    handle.destroy();
   });
 
   it("clicking modal does not close popup", () => {
@@ -147,9 +146,9 @@ describe("openPopup", () => {
     (document.querySelector(".perspective-close") as HTMLElement).click();
   });
 
-  it("ESC key closes popup", () => {
+  it("ESC key hides popup", () => {
     const onClose = vi.fn();
-    openPopup({
+    const handle = openPopup({
       researchId: "test-research-id",
       onClose,
     });
@@ -157,19 +156,21 @@ describe("openPopup", () => {
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
 
     expect(onClose).toHaveBeenCalled();
-    expect(document.querySelector(".perspective-overlay")).toBeFalsy();
+    const overlay = document.querySelector(
+      ".perspective-overlay"
+    ) as HTMLElement;
+    expect(overlay.style.display).toBe("none");
+
+    handle.destroy();
   });
 
-  it("unmount removes overlay", () => {
-    const onClose = vi.fn();
+  it("unmount removes overlay from DOM", () => {
     const handle = openPopup({
       researchId: "test-research-id",
-      onClose,
     });
 
     handle.unmount();
 
-    expect(onClose).toHaveBeenCalled();
     expect(document.querySelector(".perspective-overlay")).toBeFalsy();
     expect(
       getPersistedOpenState({
@@ -177,6 +178,24 @@ describe("openPopup", () => {
         type: "popup",
       })
     ).toBe(true);
+  });
+
+  it("show() restores hidden popup", () => {
+    const handle = openPopup({
+      researchId: "test-research-id",
+    });
+
+    handle.hide();
+    expect(handle.isOpen).toBe(false);
+
+    handle.show();
+    expect(handle.isOpen).toBe(true);
+    const overlay = document.querySelector(
+      ".perspective-overlay"
+    ) as HTMLElement;
+    expect(overlay.style.display).toBe("");
+
+    handle.destroy();
   });
 
   it("update modifies config", () => {
@@ -294,7 +313,7 @@ describe("openPopup", () => {
 
       const iframe = handle.iframe!;
 
-      // Destroy calls onClose once
+      // fullDestroy fires onClose once (was open), then tears down listeners
       handle.destroy();
       expect(onClose).toHaveBeenCalledTimes(1);
 
@@ -303,7 +322,6 @@ describe("openPopup", () => {
       sendMessage(iframe, "perspective:close");
 
       expect(onSubmit).not.toHaveBeenCalled();
-      // onClose should still be called only once (from destroy)
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
@@ -430,6 +448,35 @@ describe("openPopup", () => {
       expect(document.querySelector(".perspective-overlay")).toBeFalsy();
     });
 
+    it("update applies disableClose after mount", () => {
+      const onClose = vi.fn();
+      const handle = openPopup({
+        researchId: "test-research-id",
+        onClose,
+      });
+
+      const closeBtn = document.querySelector(
+        ".perspective-close"
+      ) as HTMLElement;
+      const overlay = document.querySelector(
+        ".perspective-overlay"
+      ) as HTMLElement;
+
+      const updatedConfig = { disableClose: true };
+      handle.update(updatedConfig);
+
+      expect(closeBtn.style.display).toBe("none");
+
+      closeBtn.click();
+      overlay.click();
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(document.querySelector(".perspective-overlay")).toBeTruthy();
+
+      handle.unmount();
+    });
+
     it("sends hasCloseButton: false in init message when disableClose is true", () => {
       const host = "https://getperspective.ai";
       const researchId = "test-research-id";
@@ -498,18 +545,259 @@ describe("openPopup", () => {
     });
   });
 
-  it("destroy is idempotent", () => {
+  describe("preloaded iframe callback replay", () => {
+    const host = "https://getperspective.ai";
+    const researchId = "test-research-id";
+
+    afterEach(() => {
+      destroyPreloaded();
+    });
+
+    const simulateReady = (iframe: HTMLIFrameElement) => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "perspective:ready", researchId },
+          origin: host,
+          source: iframe.contentWindow,
+        })
+      );
+    };
+
+    it("fires onReady immediately when claiming a ready preloaded iframe", () => {
+      const onReady = vi.fn();
+
+      preloadIframe(researchId, "popup", host);
+
+      const preloadedIframe = document.querySelector(
+        "iframe[data-perspective-preload]"
+      ) as HTMLIFrameElement;
+
+      // Simulate ready during preload phase
+      simulateReady(preloadedIframe);
+
+      // Open popup — should claim preloaded iframe and fire onReady immediately
+      const handle = openPopup({ researchId, host, onReady });
+
+      expect(onReady).toHaveBeenCalledTimes(1);
+      expect(handle.iframe).toBe(preloadedIframe);
+
+      handle.destroy();
+    });
+
+    it("does not fire onReady immediately if preloaded iframe was not ready", () => {
+      const onReady = vi.fn();
+
+      preloadIframe(researchId, "popup", host);
+
+      // Don't simulate ready — iframe is still loading
+
+      const handle = openPopup({ researchId, host, onReady });
+
+      // onReady should NOT have been called yet
+      expect(onReady).not.toHaveBeenCalled();
+
+      // But when ready fires later, it should work
+      simulateReady(handle.iframe!);
+      expect(onReady).toHaveBeenCalledTimes(1);
+
+      handle.destroy();
+    });
+
+    it("does not show loading indicator for ready preloaded iframe", () => {
+      preloadIframe(researchId, "popup", host);
+
+      const preloadedIframe = document.querySelector(
+        "iframe[data-perspective-preload]"
+      ) as HTMLIFrameElement;
+      simulateReady(preloadedIframe);
+
+      const handle = openPopup({ researchId, host });
+
+      expect(document.querySelector(".perspective-loading")).toBeFalsy();
+
+      handle.destroy();
+    });
+
+    it("shows loading indicator for claimed-but-not-ready preloaded iframe", () => {
+      preloadIframe(researchId, "popup", host);
+
+      // Don't simulate ready — claimed before ready
+
+      const handle = openPopup({ researchId, host });
+
+      // Loading indicator should be present (iframe not ready yet)
+      expect(document.querySelector(".perspective-loading")).toBeTruthy();
+
+      handle.destroy();
+    });
+
+    it("does not claim a stale preloaded iframe when config does not match", () => {
+      preloadIframe(researchId, "popup", host, { source: "first" });
+
+      const stalePreload = document.querySelector(
+        "iframe[data-perspective-preload]"
+      ) as HTMLIFrameElement;
+
+      const handle = openPopup({
+        researchId,
+        host,
+        params: { source: "second" },
+      });
+
+      expect(handle.iframe).not.toBe(stalePreload);
+      expect(
+        document.querySelector("iframe[data-perspective-preload]")
+      ).toBeFalsy();
+
+      handle.destroy();
+    });
+  });
+
+  it("hide is idempotent", () => {
     const onClose = vi.fn();
     const handle = openPopup({
       researchId: "test-research-id",
       onClose,
     });
 
-    handle.destroy();
-    handle.destroy();
-    handle.destroy();
+    handle.hide();
+    handle.hide();
+    handle.hide();
 
     // onClose only called once
     expect(onClose).toHaveBeenCalledTimes(1);
+
+    handle.destroy();
+  });
+
+  describe("_startHidden", () => {
+    it("creates popup hidden with display:none", () => {
+      const handle = openPopup({
+        researchId: "test-research-id",
+        _startHidden: true,
+      });
+
+      const overlay = document.querySelector(
+        ".perspective-overlay"
+      ) as HTMLElement;
+      expect(overlay).toBeTruthy();
+      expect(overlay.style.display).toBe("none");
+      expect(handle.isOpen).toBe(false);
+
+      handle.destroy();
+    });
+
+    it("show() makes hidden popup visible", () => {
+      const handle = openPopup({
+        researchId: "test-research-id",
+        _startHidden: true,
+      });
+
+      handle.show();
+
+      const overlay = document.querySelector(
+        ".perspective-overlay"
+      ) as HTMLElement;
+      expect(overlay.style.display).toBe("");
+      expect(handle.isOpen).toBe(true);
+
+      handle.destroy();
+    });
+
+    it("does not register ESC listener when hidden", () => {
+      const handle = openPopup({
+        researchId: "test-research-id",
+        _startHidden: true,
+      });
+
+      // ESC should not close when hidden
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      expect(handle.isOpen).toBe(false);
+
+      // After show, ESC should work
+      handle.show();
+      expect(handle.isOpen).toBe(true);
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      expect(handle.isOpen).toBe(false);
+
+      handle.destroy();
+    });
+
+    it("gates callbacks while hidden", () => {
+      const host = "https://getperspective.ai";
+      const researchId = "test-research-id";
+      const onSubmit = vi.fn();
+
+      const handle = openPopup({
+        researchId,
+        host,
+        onSubmit,
+        _startHidden: true,
+      });
+
+      // Send message while hidden — should not fire
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "perspective:submit", researchId },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      // Show and send — should fire
+      handle.show();
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "perspective:submit", researchId },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+
+      handle.destroy();
+    });
+
+    it("does not navigate parent page while hidden", () => {
+      const host = "https://getperspective.ai";
+      const researchId = "test-research-id";
+      const originalHref = window.location.href;
+      const mockLocation = { href: originalHref };
+
+      Object.defineProperty(window, "location", {
+        value: mockLocation,
+        writable: true,
+        configurable: true,
+      });
+
+      const handle = openPopup({
+        researchId,
+        host,
+        _startHidden: true,
+      });
+
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "perspective:redirect",
+            researchId,
+            url: "https://example.com/hidden-popup",
+          },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+
+      expect(mockLocation.href).toBe(originalHref);
+
+      handle.destroy();
+
+      Object.defineProperty(window, "location", {
+        value: { href: originalHref },
+        writable: true,
+        configurable: true,
+      });
+    });
   });
 });

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -3,51 +3,33 @@
  * SSR-safe - returns no-op handle on server
  */
 
-import type { EmbedConfig, EmbedHandle } from "./types";
+import type { EmbedConfig, ToggleableHandle } from "./types";
 import { hasDom, getHost } from "./config";
-import {
-  createIframe,
-  setupMessageListener,
-  registerIframe,
-  ensureGlobalListeners,
-} from "./iframe";
-import { createLoadingIndicator } from "./loading";
 import { injectStyles, CLOSE_ICON } from "./styles";
 import { setPersistedOpenState } from "./state";
 import { cn, getThemeClass } from "./utils";
+import {
+  createNoOpToggleableHandle,
+  createToggleableEmbed,
+} from "./toggleable";
 
-function createNoOpHandle(researchId: string): EmbedHandle {
-  return {
-    unmount: () => {},
-    update: () => {},
-    destroy: () => {},
-    researchId,
-    type: "popup",
-    iframe: null,
-    container: null,
-  };
-}
-
-export function openPopup(config: EmbedConfig): EmbedHandle {
+export function openPopup(
+  config: EmbedConfig & { _startHidden?: boolean }
+): ToggleableHandle {
   const { researchId } = config;
 
-  // SSR safety: return no-op handle
   if (!hasDom()) {
-    return createNoOpHandle(researchId);
+    return createNoOpToggleableHandle(researchId, "popup");
   }
-  const host = getHost(config.host);
 
   injectStyles();
-  ensureGlobalListeners();
 
-  // Create overlay
   const overlay = document.createElement("div");
   overlay.className = cn(
     "perspective-overlay perspective-embed-root",
     getThemeClass(config.theme)
   );
 
-  // Create modal container
   const modal = document.createElement("div");
   modal.className = "perspective-modal";
 
@@ -56,39 +38,10 @@ export function openPopup(config: EmbedConfig): EmbedHandle {
   closeBtn.className = "perspective-close";
   closeBtn.innerHTML = CLOSE_ICON;
   closeBtn.setAttribute("aria-label", "Close");
-  if (config.disableClose) {
-    closeBtn.style.display = "none";
-  }
-
-  // Create loading indicator with theme and brand colors
-  const loading = createLoadingIndicator({
-    theme: config.theme,
-    brand: config.brand,
-  });
-  loading.style.borderRadius = "16px";
-
-  // Create iframe (hidden initially)
-  const iframe = createIframe(
-    researchId,
-    "popup",
-    host,
-    config.params,
-    config.brand,
-    config.theme
-  );
-  iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.3s ease";
 
   modal.appendChild(closeBtn);
-  modal.appendChild(loading);
-  modal.appendChild(iframe);
   overlay.appendChild(modal);
   document.body.appendChild(overlay);
-
-  // Mutable config reference for updates
-  let currentConfig = { ...config };
-  let isOpen = true;
-  let messageCleanup: (() => void) | null = null;
   const persistOpenState = (open: boolean) => {
     setPersistedOpenState({
       researchId,
@@ -98,84 +51,45 @@ export function openPopup(config: EmbedConfig): EmbedHandle {
     });
   };
 
-  // Register iframe for theme change notifications
-  const unregisterIframe = registerIframe(iframe, host);
-
-  persistOpenState(true);
-
-  const removePopup = () => {
-    if (!isOpen) return;
-    isOpen = false;
-    messageCleanup?.();
-    unregisterIframe();
-    overlay.remove();
-    document.removeEventListener("keydown", escHandler);
-    currentConfig.onClose?.();
-  };
-
-  const destroy = () => {
-    persistOpenState(false);
-    removePopup();
-  };
-
-  const unmount = () => {
-    removePopup();
-  };
-
-  // Set up message listener with loading state handling
-  messageCleanup = setupMessageListener(
-    researchId,
+  return createToggleableEmbed(
+    config,
+    "popup",
     {
-      get onReady() {
+      container: overlay,
+      contentParent: modal,
+      show: () => {
+        overlay.style.display = "";
+      },
+      hide: () => {
+        overlay.style.display = "none";
+      },
+      remove: () => {
+        overlay.remove();
+      },
+      bindCloseHandlers: (requestClose) => {
+        const handleCloseButton = () => requestClose();
+        const handleOverlayClick = (event: MouseEvent) => {
+          if (event.target === overlay) {
+            requestClose();
+          }
+        };
+
+        closeBtn.addEventListener("click", handleCloseButton);
+        overlay.addEventListener("click", handleOverlayClick);
+
         return () => {
-          loading.style.opacity = "0";
-          iframe.style.opacity = "1";
-          setTimeout(() => loading.remove(), 300);
-          currentConfig.onReady?.();
+          closeBtn.removeEventListener("click", handleCloseButton);
+          overlay.removeEventListener("click", handleOverlayClick);
         };
       },
-      get onSubmit() {
-        return currentConfig.onSubmit;
+      setCloseEnabled: (enabled) => {
+        closeBtn.style.display = enabled ? "" : "none";
       },
-      get onNavigate() {
-        return currentConfig.onNavigate;
-      },
-      get onClose() {
-        return destroy;
-      },
-      get onError() {
-        return currentConfig.onError;
+      loadingStyle: (loading) => {
+        loading.style.borderRadius = "16px";
       },
     },
-    iframe,
-    host,
-    { skipResize: true, hasCloseButton: !config.disableClose }
+    getHost(config.host),
+    { persistOpenState }
   );
-
-  // Close handlers (disabled when disableClose is enabled)
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      destroy();
-    }
-  };
-
-  if (!config.disableClose) {
-    closeBtn.addEventListener("click", destroy);
-    overlay.addEventListener("click", (e) => {
-      if (e.target === overlay) destroy();
-    });
-    document.addEventListener("keydown", escHandler);
-  }
-
-  return {
-    unmount,
-    update: (options: Parameters<EmbedHandle["update"]>[0]) => {
-      currentConfig = { ...currentConfig, ...options };
-    },
-    destroy,
-    researchId,
-    type: "popup" as const,
-    iframe,
-    container: overlay,
-  };
 }

--- a/packages/sdk/src/preload.test.ts
+++ b/packages/sdk/src/preload.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  preloadIframe,
+  ensurePreloadedIframe,
+  claimPreloadedIframe,
+  destroyPreloaded,
+  destroyPreloadedByType,
+} from "./preload";
+
+describe("preloadIframe", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+  afterEach(() => {
+    destroyPreloaded();
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("creates a hidden iframe in the DOM", () => {
+    preloadIframe("test-research", "popup", "https://getperspective.ai");
+
+    const iframe = document.querySelector(
+      "iframe[data-perspective-preload]"
+    ) as HTMLIFrameElement;
+    expect(iframe).not.toBeNull();
+    expect(iframe.style.opacity).toBe("0");
+    expect(iframe.src).toContain("/interview/test-research");
+  });
+
+  it("replaces preloaded iframe for same researchId + type", () => {
+    preloadIframe("research-1", "popup", "https://getperspective.ai");
+    preloadIframe("research-1", "popup", "https://getperspective.ai");
+
+    const iframes = document.querySelectorAll(
+      "iframe[data-perspective-preload]"
+    );
+    expect(iframes.length).toBe(1);
+  });
+
+  it("ensurePreloadedIframe keeps the existing iframe for same researchId + type", () => {
+    preloadIframe("research-1", "popup", "https://getperspective.ai");
+    const firstIframe = document.querySelector(
+      "iframe[data-perspective-preload]"
+    ) as HTMLIFrameElement;
+
+    ensurePreloadedIframe("research-1", "popup", "https://getperspective.ai");
+
+    const iframes = document.querySelectorAll(
+      "iframe[data-perspective-preload]"
+    );
+    expect(iframes.length).toBe(1);
+    expect(iframes[0]).toBe(firstIframe);
+  });
+
+  it("allows multiple preloaded iframes for different types", () => {
+    preloadIframe("research-1", "popup", "https://getperspective.ai");
+    preloadIframe("research-1", "float", "https://getperspective.ai");
+
+    const iframes = document.querySelectorAll(
+      "iframe[data-perspective-preload]"
+    );
+    expect(iframes.length).toBe(2);
+  });
+
+  it("allows multiple preloaded iframes for different researchIds", () => {
+    preloadIframe("research-1", "popup", "https://getperspective.ai");
+    preloadIframe("research-2", "popup", "https://getperspective.ai");
+
+    const iframes = document.querySelectorAll(
+      "iframe[data-perspective-preload]"
+    );
+    expect(iframes.length).toBe(2);
+  });
+
+  it("claimPreloadedIframe returns the iframe and clears state", () => {
+    preloadIframe("test-research", "popup", "https://getperspective.ai");
+
+    const claimed = claimPreloadedIframe("test-research", "popup");
+    expect(claimed).not.toBeNull();
+    expect(claimed?.iframe.getAttribute("data-perspective-preload")).toBeNull();
+    expect(claimed?.wasReady).toBe(false);
+
+    const again = claimPreloadedIframe("test-research", "popup");
+    expect(again).toBeNull();
+  });
+
+  it("claimPreloadedIframe returns null for mismatched researchId", () => {
+    preloadIframe("test-research", "popup", "https://getperspective.ai");
+    expect(claimPreloadedIframe("wrong-id", "popup")).toBeNull();
+  });
+
+  it("claimPreloadedIframe returns null for mismatched type", () => {
+    preloadIframe("test-research", "popup", "https://getperspective.ai");
+    expect(claimPreloadedIframe("test-research", "slider")).toBeNull();
+  });
+
+  it("claimPreloadedIframe discards stale preloads when the expected signature differs", () => {
+    preloadIframe("test-research", "popup", "https://getperspective.ai", {
+      source: "first",
+    });
+
+    const claimed = claimPreloadedIframe(
+      "test-research",
+      "popup",
+      "stale-signature"
+    );
+
+    expect(claimed).toBeNull();
+    expect(
+      document.querySelector("iframe[data-perspective-preload]")
+    ).toBeNull();
+  });
+
+  it("destroyPreloaded removes all preloaded iframes from DOM", () => {
+    preloadIframe("research-1", "popup", "https://getperspective.ai");
+    preloadIframe("research-1", "float", "https://getperspective.ai");
+    destroyPreloaded();
+    expect(
+      document.querySelector("iframe[data-perspective-preload]")
+    ).toBeNull();
+  });
+
+  it("destroyPreloadedByType removes only the matching iframe", () => {
+    preloadIframe("research-1", "popup", "https://getperspective.ai");
+    preloadIframe("research-1", "float", "https://getperspective.ai");
+    destroyPreloadedByType("research-1", "popup");
+
+    const iframes = document.querySelectorAll(
+      "iframe[data-perspective-preload]"
+    );
+    expect(iframes.length).toBe(1);
+    expect(claimPreloadedIframe("research-1", "float")).not.toBeNull();
+  });
+
+  it("wasReady is true after perspective:ready fires during preload", () => {
+    const host = "https://getperspective.ai";
+    preloadIframe("test-research", "popup", host);
+
+    const iframe = document.querySelector(
+      "iframe[data-perspective-preload]"
+    ) as HTMLIFrameElement;
+
+    // Simulate perspective:ready from iframe
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "perspective:ready", researchId: "test-research" },
+        origin: host,
+        source: iframe.contentWindow,
+      })
+    );
+
+    const claimed = claimPreloadedIframe("test-research", "popup");
+    expect(claimed).not.toBeNull();
+    expect(claimed?.wasReady).toBe(true);
+  });
+});

--- a/packages/sdk/src/preload.ts
+++ b/packages/sdk/src/preload.ts
@@ -1,0 +1,222 @@
+/**
+ * Hidden iframe preloading for button-triggered embeds
+ * SSR-safe - all DOM access is guarded
+ */
+
+import type { BrandColors, EmbedType, ThemeValue } from "./types";
+import { hasDom } from "./config";
+import {
+  createIframe,
+  setupMessageListener,
+  registerIframe,
+  ensureGlobalListeners,
+} from "./iframe";
+import { getTimer, removeTimer } from "./timing";
+import { getResolvedReusableEmbedSignature } from "./reuse";
+
+const PRELOAD_ATTR = "data-perspective-preload";
+
+type PreloadState = {
+  iframe: HTMLIFrameElement;
+  researchId: string;
+  type: EmbedType;
+  signature: string;
+  cleanup: () => void;
+  ready: boolean;
+};
+
+function preloadKey(researchId: string, type: EmbedType): string {
+  return `${researchId}:${type}`;
+}
+
+const preloaded = new Map<string, PreloadState>();
+
+/**
+ * Preload an iframe in a hidden state for a button-triggered embed.
+ * Multiple preloaded iframes can coexist, keyed by researchId + type.
+ * Re-preloading the same researchId + type replaces the previous one.
+ */
+export function preloadIframe(
+  researchId: string,
+  type: EmbedType,
+  host: string,
+  params?: Record<string, string>,
+  brand?: { light?: BrandColors; dark?: BrandColors },
+  themeOverride?: ThemeValue
+): void {
+  if (!hasDom()) return;
+
+  const key = preloadKey(researchId, type);
+  destroyPreloadedEntry(key);
+  createPreloadedEntry(
+    key,
+    researchId,
+    type,
+    host,
+    params,
+    brand,
+    themeOverride
+  );
+}
+
+export function ensurePreloadedIframe(
+  researchId: string,
+  type: EmbedType,
+  host: string,
+  params?: Record<string, string>,
+  brand?: { light?: BrandColors; dark?: BrandColors },
+  themeOverride?: ThemeValue
+): void {
+  if (!hasDom()) return;
+
+  const key = preloadKey(researchId, type);
+  const signature = getResolvedReusableEmbedSignature({
+    host,
+    params,
+    brand,
+    theme: themeOverride,
+  });
+  const existing = preloaded.get(key);
+  if (existing?.signature === signature) return;
+  if (existing) {
+    destroyPreloadedEntry(key);
+  }
+  createPreloadedEntry(
+    key,
+    researchId,
+    type,
+    host,
+    params,
+    brand,
+    themeOverride
+  );
+}
+
+function createPreloadedEntry(
+  key: string,
+  researchId: string,
+  type: EmbedType,
+  host: string,
+  params?: Record<string, string>,
+  brand?: { light?: BrandColors; dark?: BrandColors },
+  themeOverride?: ThemeValue
+): void {
+  ensureGlobalListeners();
+
+  const iframe = createIframe(
+    researchId,
+    type,
+    host,
+    params,
+    brand,
+    themeOverride
+  );
+  iframe.setAttribute(PRELOAD_ATTR, researchId);
+  iframe.style.position = "fixed";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.opacity = "0";
+  iframe.style.pointerEvents = "none";
+  iframe.style.overflow = "hidden";
+
+  // Set up message listener so perspective:ready is handled during preload.
+  // Track ready state so callers know if callbacks need replaying after claim.
+  const state: PreloadState = {
+    iframe,
+    researchId,
+    type,
+    signature: getResolvedReusableEmbedSignature({
+      host,
+      params,
+      brand,
+      theme: themeOverride,
+    }),
+    ready: false,
+    cleanup: () => {},
+  };
+  const msgCleanup = setupMessageListener(
+    researchId,
+    {
+      onReady: () => {
+        state.ready = true;
+      },
+    },
+    iframe,
+    host,
+    { skipResize: true, preloadOnly: true }
+  );
+  const unregister = registerIframe(iframe, host);
+
+  document.body.appendChild(iframe);
+  state.cleanup = () => {
+    msgCleanup();
+    unregister();
+  };
+  preloaded.set(key, state);
+
+  getTimer(researchId).mark("iframe:preloadStarted");
+}
+
+export type ClaimedPreload = {
+  iframe: HTMLIFrameElement;
+  /** Whether perspective:ready already fired during preload */
+  wasReady: boolean;
+};
+
+/**
+ * Claim a preloaded iframe for use. Returns the iframe and its ready state
+ * if available for the given researchId + type, or null. Caller is responsible
+ * for moving it into the target container, re-setting up message listeners,
+ * and replaying onReady/onAuth if wasReady is true.
+ */
+export function claimPreloadedIframe(
+  researchId: string,
+  type: EmbedType,
+  expectedSignature?: string
+): ClaimedPreload | null {
+  const key = preloadKey(researchId, type);
+  const state = preloaded.get(key);
+  if (!state) return null;
+  if (expectedSignature && state.signature !== expectedSignature) {
+    destroyPreloadedEntry(key);
+    return null;
+  }
+  return claimState(key, state);
+}
+
+function claimState(key: string, state: PreloadState): ClaimedPreload {
+  const { iframe, cleanup, ready, researchId } = state;
+  iframe.removeAttribute(PRELOAD_ATTR);
+
+  // Clean up preload-phase listeners — caller will set up their own
+  cleanup();
+  preloaded.delete(key);
+
+  getTimer(researchId).mark("iframe:preloadClaimed");
+  return { iframe, wasReady: ready };
+}
+
+/** Destroy a specific preloaded iframe by researchId + type */
+export function destroyPreloadedByType(
+  researchId: string,
+  type: EmbedType
+): void {
+  destroyPreloadedEntry(preloadKey(researchId, type));
+}
+
+/** Destroy all preloaded iframes */
+export function destroyPreloaded(): void {
+  for (const [key] of preloaded) {
+    destroyPreloadedEntry(key);
+  }
+}
+
+function destroyPreloadedEntry(key: string): void {
+  const state = preloaded.get(key);
+  if (state) {
+    state.cleanup();
+    state.iframe.remove();
+    removeTimer(state.researchId);
+    preloaded.delete(key);
+  }
+}

--- a/packages/sdk/src/reuse.ts
+++ b/packages/sdk/src/reuse.ts
@@ -1,0 +1,51 @@
+import type { BrandColors, EmbedConfig, ThemeValue } from "./types";
+import { getHost, hasDom } from "./config";
+
+function sortObjectKeys(value: unknown): unknown {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((result, key) => {
+        result[key] = (value as Record<string, unknown>)[key];
+        return result;
+      }, {});
+  }
+
+  return value;
+}
+
+export function stableSerialize(value: unknown): string {
+  return JSON.stringify(value, (_key, currentValue) =>
+    sortObjectKeys(currentValue)
+  );
+}
+
+export function getResolvedReusableEmbedSignature(options: {
+  host: string;
+  theme?: ThemeValue;
+  params?: Record<string, string>;
+  disableClose?: boolean;
+  brand?: {
+    light?: BrandColors;
+    dark?: BrandColors;
+  };
+}): string {
+  return stableSerialize({
+    host: options.host,
+    theme: options.theme ?? null,
+    params: options.params ?? null,
+    disableClose: options.disableClose ?? null,
+    brand: options.brand ?? null,
+    parentSearch: hasDom() ? window.location.search : "",
+  });
+}
+
+export function getReusableEmbedSignature(config: EmbedConfig): string {
+  return getResolvedReusableEmbedSignature({
+    host: getHost(config.host),
+    theme: config.theme,
+    params: config.params,
+    disableClose: config.disableClose,
+    brand: config.brand,
+  });
+}

--- a/packages/sdk/src/slider.test.ts
+++ b/packages/sdk/src/slider.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { openSlider } from "./slider";
+import { preloadIframe, destroyPreloaded } from "./preload";
 import * as config from "./config";
 import { getPersistedOpenState } from "./state";
 
@@ -90,9 +91,9 @@ describe("openSlider", () => {
     ).toBe(false);
   });
 
-  it("closes on close button click", () => {
+  it("close button hides slider and fires onClose", () => {
     const onClose = vi.fn();
-    openSlider({
+    const handle = openSlider({
       researchId: "test-research-id",
       onClose,
     });
@@ -104,13 +105,17 @@ describe("openSlider", () => {
 
     closeBtn.click();
 
-    expect(document.querySelector(".perspective-slider")).toBeFalsy();
+    const slider = document.querySelector(".perspective-slider") as HTMLElement;
+    expect(slider.style.display).toBe("none");
     expect(onClose).toHaveBeenCalled();
+    expect(handle.isOpen).toBe(false);
+
+    handle.destroy();
   });
 
-  it("closes on backdrop click", () => {
+  it("backdrop click hides slider", () => {
     const onClose = vi.fn();
-    openSlider({
+    const handle = openSlider({
       researchId: "test-research-id",
       onClose,
     });
@@ -122,13 +127,15 @@ describe("openSlider", () => {
 
     backdrop.click();
 
-    expect(document.querySelector(".perspective-slider")).toBeFalsy();
+    expect(backdrop.style.display).toBe("none");
     expect(onClose).toHaveBeenCalled();
+
+    handle.destroy();
   });
 
-  it("closes on Escape key", () => {
+  it("ESC key hides slider", () => {
     const onClose = vi.fn();
-    openSlider({
+    const handle = openSlider({
       researchId: "test-research-id",
       onClose,
     });
@@ -137,22 +144,43 @@ describe("openSlider", () => {
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
 
-    expect(document.querySelector(".perspective-slider")).toBeFalsy();
+    const slider = document.querySelector(".perspective-slider") as HTMLElement;
+    expect(slider.style.display).toBe("none");
     expect(onClose).toHaveBeenCalled();
+
+    handle.destroy();
   });
 
-  it("only closes once on multiple triggers", () => {
+  it("hide is idempotent", () => {
     const onClose = vi.fn();
     const handle = openSlider({
       researchId: "test-research-id",
       onClose,
     });
 
-    handle.unmount();
-    handle.unmount();
-    handle.unmount();
+    handle.hide();
+    handle.hide();
+    handle.hide();
 
     expect(onClose).toHaveBeenCalledTimes(1);
+
+    handle.destroy();
+  });
+
+  it("show() restores hidden slider", () => {
+    const handle = openSlider({
+      researchId: "test-research-id",
+    });
+
+    handle.hide();
+    expect(handle.isOpen).toBe(false);
+
+    handle.show();
+    expect(handle.isOpen).toBe(true);
+    const slider = document.querySelector(".perspective-slider") as HTMLElement;
+    expect(slider.style.display).toBe("");
+
+    handle.destroy();
   });
 
   it("applies theme class", () => {
@@ -275,6 +303,34 @@ describe("openSlider", () => {
       expect(onClose).toHaveBeenCalledTimes(1);
       expect(document.querySelector(".perspective-slider")).toBeFalsy();
     });
+
+    it("update re-enables close affordances", () => {
+      const onClose = vi.fn();
+      const handle = openSlider({
+        researchId: "test-research-id",
+        disableClose: true,
+        onClose,
+      });
+
+      const closeBtn = document.querySelector(
+        ".perspective-close"
+      ) as HTMLElement;
+      const backdrop = document.querySelector(
+        ".perspective-slider-backdrop"
+      ) as HTMLElement;
+
+      const updatedConfig = { disableClose: false };
+      handle.update(updatedConfig);
+
+      expect(closeBtn.style.display).toBe("");
+
+      backdrop.click();
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(document.querySelector(".perspective-slider")).toBeTruthy();
+
+      handle.unmount();
+    });
   });
 
   describe("update() behavior", () => {
@@ -351,6 +407,7 @@ describe("openSlider", () => {
 
       const iframe = handle.iframe!;
 
+      // fullDestroy fires onClose once (was open), then tears down listeners
       handle.unmount();
       expect(onClose).toHaveBeenCalledTimes(1);
 
@@ -370,6 +427,221 @@ describe("openSlider", () => {
       handle.unmount();
 
       expect(() => handle.update({ onSubmit: vi.fn() })).not.toThrow();
+    });
+  });
+
+  describe("preloaded iframe callback replay", () => {
+    const host = "https://getperspective.ai";
+    const researchId = "test-research-id";
+
+    afterEach(() => {
+      destroyPreloaded();
+    });
+
+    const simulateReady = (iframe: HTMLIFrameElement) => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "perspective:ready", researchId },
+          origin: host,
+          source: iframe.contentWindow,
+        })
+      );
+    };
+
+    it("fires onReady immediately when claiming a ready preloaded iframe", () => {
+      const onReady = vi.fn();
+
+      preloadIframe(researchId, "slider", host);
+
+      const preloadedIframe = document.querySelector(
+        "iframe[data-perspective-preload]"
+      ) as HTMLIFrameElement;
+
+      simulateReady(preloadedIframe);
+
+      const handle = openSlider({ researchId, host, onReady });
+
+      expect(onReady).toHaveBeenCalledTimes(1);
+      expect(handle.iframe).toBe(preloadedIframe);
+
+      handle.destroy();
+    });
+
+    it("does not fire onReady immediately if preloaded iframe was not ready", () => {
+      const onReady = vi.fn();
+
+      preloadIframe(researchId, "slider", host);
+
+      const handle = openSlider({ researchId, host, onReady });
+
+      expect(onReady).not.toHaveBeenCalled();
+
+      simulateReady(handle.iframe!);
+      expect(onReady).toHaveBeenCalledTimes(1);
+
+      handle.destroy();
+    });
+
+    it("does not show loading indicator for ready preloaded iframe", () => {
+      preloadIframe(researchId, "slider", host);
+
+      const preloadedIframe = document.querySelector(
+        "iframe[data-perspective-preload]"
+      ) as HTMLIFrameElement;
+      simulateReady(preloadedIframe);
+
+      const handle = openSlider({ researchId, host });
+
+      expect(document.querySelector(".perspective-loading")).toBeFalsy();
+
+      handle.destroy();
+    });
+
+    it("shows loading indicator for claimed-but-not-ready preloaded iframe", () => {
+      preloadIframe(researchId, "slider", host);
+
+      // Don't simulate ready — claimed before ready
+
+      const handle = openSlider({ researchId, host });
+
+      // Loading indicator should be present (iframe not ready yet)
+      expect(document.querySelector(".perspective-loading")).toBeTruthy();
+
+      handle.destroy();
+    });
+  });
+
+  describe("_startHidden", () => {
+    it("creates slider hidden with display:none", () => {
+      const handle = openSlider({
+        researchId: "test-research-id",
+        _startHidden: true,
+      });
+
+      const slider = document.querySelector(
+        ".perspective-slider"
+      ) as HTMLElement;
+      const backdrop = document.querySelector(
+        ".perspective-slider-backdrop"
+      ) as HTMLElement;
+      expect(slider.style.display).toBe("none");
+      expect(backdrop.style.display).toBe("none");
+      expect(handle.isOpen).toBe(false);
+
+      handle.destroy();
+    });
+
+    it("show() makes hidden slider visible", () => {
+      const handle = openSlider({
+        researchId: "test-research-id",
+        _startHidden: true,
+      });
+
+      handle.show();
+
+      const slider = document.querySelector(
+        ".perspective-slider"
+      ) as HTMLElement;
+      const backdrop = document.querySelector(
+        ".perspective-slider-backdrop"
+      ) as HTMLElement;
+      expect(slider.style.display).toBe("");
+      expect(backdrop.style.display).toBe("");
+      expect(handle.isOpen).toBe(true);
+
+      handle.destroy();
+    });
+
+    it("does not register ESC listener when hidden", () => {
+      const handle = openSlider({
+        researchId: "test-research-id",
+        _startHidden: true,
+      });
+
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      expect(handle.isOpen).toBe(false);
+
+      handle.show();
+      expect(handle.isOpen).toBe(true);
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      expect(handle.isOpen).toBe(false);
+
+      handle.destroy();
+    });
+
+    it("gates callbacks while hidden", () => {
+      const host = "https://getperspective.ai";
+      const researchId = "test-research-id";
+      const onSubmit = vi.fn();
+
+      const handle = openSlider({
+        researchId,
+        host,
+        onSubmit,
+        _startHidden: true,
+      });
+
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "perspective:submit", researchId },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      handle.show();
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: { type: "perspective:submit", researchId },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+
+      handle.destroy();
+    });
+
+    it("does not navigate parent page while hidden", () => {
+      const host = "https://getperspective.ai";
+      const researchId = "test-research-id";
+      const originalHref = window.location.href;
+      const mockLocation = { href: originalHref };
+
+      Object.defineProperty(window, "location", {
+        value: mockLocation,
+        writable: true,
+        configurable: true,
+      });
+
+      const handle = openSlider({
+        researchId,
+        host,
+        _startHidden: true,
+      });
+
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "perspective:redirect",
+            researchId,
+            url: "https://example.com/hidden-slider",
+          },
+          origin: host,
+          source: handle.iframe!.contentWindow,
+        })
+      );
+
+      expect(mockLocation.href).toBe(originalHref);
+
+      handle.destroy();
+
+      Object.defineProperty(window, "location", {
+        value: { href: originalHref },
+        writable: true,
+        configurable: true,
+      });
     });
   });
 });

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -3,51 +3,33 @@
  * SSR-safe - returns no-op handle on server
  */
 
-import type { EmbedConfig, EmbedHandle } from "./types";
+import type { EmbedConfig, ToggleableHandle } from "./types";
 import { hasDom, getHost } from "./config";
-import {
-  createIframe,
-  setupMessageListener,
-  registerIframe,
-  ensureGlobalListeners,
-} from "./iframe";
-import { createLoadingIndicator } from "./loading";
 import { injectStyles, CLOSE_ICON } from "./styles";
 import { setPersistedOpenState } from "./state";
 import { cn, getThemeClass } from "./utils";
+import {
+  createNoOpToggleableHandle,
+  createToggleableEmbed,
+} from "./toggleable";
 
-function createNoOpHandle(researchId: string): EmbedHandle {
-  return {
-    unmount: () => {},
-    update: () => {},
-    destroy: () => {},
-    researchId,
-    type: "slider",
-    iframe: null,
-    container: null,
-  };
-}
-
-export function openSlider(config: EmbedConfig): EmbedHandle {
+export function openSlider(
+  config: EmbedConfig & { _startHidden?: boolean }
+): ToggleableHandle {
   const { researchId } = config;
 
-  // SSR safety: return no-op handle
   if (!hasDom()) {
-    return createNoOpHandle(researchId);
+    return createNoOpToggleableHandle(researchId, "slider");
   }
-  const host = getHost(config.host);
 
   injectStyles();
-  ensureGlobalListeners();
 
-  // Create backdrop
   const backdrop = document.createElement("div");
   backdrop.className = cn(
     "perspective-slider-backdrop perspective-embed-root",
     getThemeClass(config.theme)
   );
 
-  // Create slider container
   const slider = document.createElement("div");
   slider.className = cn(
     "perspective-slider perspective-embed-root",
@@ -59,38 +41,10 @@ export function openSlider(config: EmbedConfig): EmbedHandle {
   closeBtn.className = "perspective-close";
   closeBtn.innerHTML = CLOSE_ICON;
   closeBtn.setAttribute("aria-label", "Close");
-  if (config.disableClose) {
-    closeBtn.style.display = "none";
-  }
-
-  // Create loading indicator with theme and brand colors
-  const loading = createLoadingIndicator({
-    theme: config.theme,
-    brand: config.brand,
-  });
-
-  // Create iframe (hidden initially)
-  const iframe = createIframe(
-    researchId,
-    "slider",
-    host,
-    config.params,
-    config.brand,
-    config.theme
-  );
-  iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.3s ease";
 
   slider.appendChild(closeBtn);
-  slider.appendChild(loading);
-  slider.appendChild(iframe);
   document.body.appendChild(backdrop);
   document.body.appendChild(slider);
-
-  // Mutable config reference for updates
-  let currentConfig = { ...config };
-  let isOpen = true;
-  let messageCleanup: (() => void) | null = null;
   const persistOpenState = (open: boolean) => {
     setPersistedOpenState({
       researchId,
@@ -100,83 +54,41 @@ export function openSlider(config: EmbedConfig): EmbedHandle {
     });
   };
 
-  // Register iframe for theme change notifications
-  const unregisterIframe = registerIframe(iframe, host);
-
-  persistOpenState(true);
-
-  const removeSlider = () => {
-    if (!isOpen) return;
-    isOpen = false;
-    messageCleanup?.();
-    unregisterIframe();
-    slider.remove();
-    backdrop.remove();
-    document.removeEventListener("keydown", escHandler);
-    currentConfig.onClose?.();
-  };
-
-  const destroy = () => {
-    persistOpenState(false);
-    removeSlider();
-  };
-
-  const unmount = () => {
-    removeSlider();
-  };
-
-  // Set up message listener with loading state handling
-  messageCleanup = setupMessageListener(
-    researchId,
+  return createToggleableEmbed(
+    config,
+    "slider",
     {
-      get onReady() {
+      container: slider,
+      contentParent: slider,
+      show: () => {
+        slider.style.display = "";
+        backdrop.style.display = "";
+      },
+      hide: () => {
+        slider.style.display = "none";
+        backdrop.style.display = "none";
+      },
+      remove: () => {
+        slider.remove();
+        backdrop.remove();
+      },
+      bindCloseHandlers: (requestClose) => {
+        const handleCloseButton = () => requestClose();
+        const handleBackdropClick = () => requestClose();
+
+        closeBtn.addEventListener("click", handleCloseButton);
+        backdrop.addEventListener("click", handleBackdropClick);
+
         return () => {
-          loading.style.opacity = "0";
-          iframe.style.opacity = "1";
-          setTimeout(() => loading.remove(), 300);
-          currentConfig.onReady?.();
+          closeBtn.removeEventListener("click", handleCloseButton);
+          backdrop.removeEventListener("click", handleBackdropClick);
         };
       },
-      get onSubmit() {
-        return currentConfig.onSubmit;
-      },
-      get onNavigate() {
-        return currentConfig.onNavigate;
-      },
-      get onClose() {
-        return destroy;
-      },
-      get onError() {
-        return currentConfig.onError;
+      setCloseEnabled: (enabled) => {
+        closeBtn.style.display = enabled ? "" : "none";
       },
     },
-    iframe,
-    host,
-    { skipResize: true, hasCloseButton: !config.disableClose }
+    getHost(config.host),
+    { persistOpenState }
   );
-
-  // Close handlers (disabled when disableClose is enabled)
-  const escHandler = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      destroy();
-    }
-  };
-
-  if (!config.disableClose) {
-    closeBtn.addEventListener("click", destroy);
-    backdrop.addEventListener("click", destroy);
-    document.addEventListener("keydown", escHandler);
-  }
-
-  return {
-    unmount,
-    update: (options: Parameters<EmbedHandle["update"]>[0]) => {
-      currentConfig = { ...currentConfig, ...options };
-    },
-    destroy,
-    researchId,
-    type: "slider" as const,
-    iframe,
-    container: slider,
-  };
 }

--- a/packages/sdk/src/styles.ts
+++ b/packages/sdk/src/styles.ts
@@ -126,10 +126,6 @@ export function injectStyles(): void {
       to { opacity: 1; }
     }
 
-    @keyframes perspective-spin {
-      to { transform: rotate(360deg); }
-    }
-
     /* Modal container */
     .perspective-modal {
       position: relative;

--- a/packages/sdk/src/timing.ts
+++ b/packages/sdk/src/timing.ts
@@ -1,0 +1,56 @@
+/**
+ * Performance timing for embed load waterfall
+ * SSR-safe - uses performance.now() when available
+ */
+
+const timers = new Map<string, EmbedTimer>();
+const shouldLogTimings =
+  typeof process !== "undefined" && process.env?.NODE_ENV === "development";
+
+export class EmbedTimer {
+  private startTime: number;
+  private marks = new Map<string, number>();
+
+  constructor(public readonly researchId: string) {
+    this.startTime = typeof performance !== "undefined" ? performance.now() : 0;
+  }
+
+  mark(name: string): void {
+    if (typeof performance === "undefined") return;
+    this.marks.set(name, performance.now() - this.startTime);
+  }
+
+  getMark(name: string): number | undefined {
+    return this.marks.get(name);
+  }
+
+  log(): void {
+    if (!shouldLogTimings || typeof console === "undefined") return;
+
+    const entries = Array.from(this.marks.entries());
+    if (entries.length === 0) return;
+
+    const total = entries[entries.length - 1]?.[1] ?? 0;
+
+    console.groupCollapsed(
+      `[Perspective] Embed timing: ${total.toFixed(0)}ms (${this.researchId})`
+    );
+    for (const [name, time] of entries) {
+      console.debug(`  ${name.padEnd(22)} → ${time.toFixed(0)}ms`);
+    }
+    console.groupEnd();
+  }
+}
+
+export function getTimer(researchId: string): EmbedTimer {
+  let timer = timers.get(researchId);
+  if (!timer) {
+    timer = new EmbedTimer(researchId);
+    timers.set(researchId, timer);
+  }
+  return timer;
+}
+
+export function removeTimer(researchId: string): void {
+  timers.delete(researchId);
+}

--- a/packages/sdk/src/toggleable.ts
+++ b/packages/sdk/src/toggleable.ts
@@ -1,0 +1,156 @@
+import type { EmbedConfig, ToggleableHandle } from "./types";
+import { removeTimer } from "./timing";
+import { getReusableEmbedSignature } from "./reuse";
+import { createEmbedFrameSession } from "./frame-session";
+
+type ToggleableType = "popup" | "slider";
+
+export interface ToggleableDomController {
+  container: HTMLElement | null;
+  contentParent: HTMLElement;
+  show: () => void;
+  hide: () => void;
+  remove: () => void;
+  bindCloseHandlers: (requestClose: () => void) => () => void;
+  setCloseEnabled?: (enabled: boolean) => void;
+  loadingStyle?: (loading: HTMLElement) => void;
+}
+
+export function createNoOpToggleableHandle(
+  researchId: string,
+  type: ToggleableType
+): ToggleableHandle {
+  return {
+    unmount: () => {},
+    update: () => {},
+    destroy: () => {},
+    show: () => {},
+    hide: () => {},
+    canReuse: () => false,
+    replayOpenCallbacks: () => {},
+    isOpen: false,
+    researchId,
+    type,
+    iframe: null,
+    container: null,
+  };
+}
+
+export function createToggleableEmbed(
+  config: EmbedConfig & { _startHidden?: boolean },
+  type: ToggleableType,
+  dom: ToggleableDomController,
+  host: string,
+  options?: {
+    persistOpenState?: (open: boolean) => void;
+  }
+): ToggleableHandle {
+  const { researchId, _startHidden } = config;
+  const persistOpenState = options?.persistOpenState;
+  let currentConfig = { ...config };
+  let isOpen = !_startHidden;
+
+  const escHandler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") requestClose();
+  };
+
+  const hide = () => {
+    if (!isOpen) return;
+    isOpen = false;
+    persistOpenState?.(false);
+    dom.hide();
+    document.removeEventListener("keydown", escHandler);
+    currentConfig.onClose?.();
+  };
+
+  const syncCloseAffordances = () => {
+    const closeEnabled = !currentConfig.disableClose;
+    dom.setCloseEnabled?.(closeEnabled);
+
+    if (!isOpen) return;
+
+    if (closeEnabled) {
+      document.addEventListener("keydown", escHandler);
+    } else {
+      document.removeEventListener("keydown", escHandler);
+    }
+  };
+
+  const requestClose = () => {
+    if (currentConfig.disableClose) return;
+    hide();
+  };
+
+  if (_startHidden) {
+    dom.hide();
+  } else {
+    persistOpenState?.(true);
+  }
+  syncCloseAffordances();
+
+  const frameSession = createEmbedFrameSession({
+    config,
+    type,
+    host,
+    contentParent: dom.contentParent,
+    getConfig: () => currentConfig,
+    isOpen: () => isOpen,
+    onClose: hide,
+    loadingStyle: dom.loadingStyle,
+    hasCloseButton: !currentConfig.disableClose,
+  });
+
+  const show = () => {
+    if (isOpen) return;
+    isOpen = true;
+    persistOpenState?.(true);
+    dom.show();
+    syncCloseAffordances();
+  };
+
+  const cleanupCloseHandlers = dom.bindCloseHandlers(requestClose);
+
+  if (!_startHidden && !currentConfig.disableClose) {
+    document.addEventListener("keydown", escHandler);
+  }
+
+  const teardown = () => {
+    const wasOpen = isOpen;
+    isOpen = false;
+    cleanupCloseHandlers();
+    frameSession.cleanup();
+    dom.remove();
+    document.removeEventListener("keydown", escHandler);
+    removeTimer(researchId);
+    if (wasOpen) currentConfig.onClose?.();
+  };
+
+  const destroy = () => {
+    persistOpenState?.(false);
+    teardown();
+  };
+
+  return {
+    unmount: teardown,
+    update: (options: Parameters<ToggleableHandle["update"]>[0]) => {
+      const previousDisableClose = Boolean(currentConfig.disableClose);
+      currentConfig = { ...currentConfig, ...options };
+      if (previousDisableClose !== Boolean(currentConfig.disableClose)) {
+        syncCloseAffordances();
+      }
+    },
+    destroy,
+    show,
+    hide,
+    canReuse: (nextConfig: EmbedConfig) =>
+      getReusableEmbedSignature(nextConfig) === frameSession.reuseSignature,
+    replayOpenCallbacks: frameSession.replayOpenCallbacks,
+    get isOpen() {
+      return isOpen;
+    },
+    researchId,
+    type,
+    iframe: frameSession.iframe,
+    container: dom.container,
+  };
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -95,8 +95,6 @@ export interface EmbedConfig {
   channel?: AIAssistantChannel | AIAssistantChannel[] | null;
   /** Welcome message shown as a teaser bubble next to the float button. Only used for float-type embeds. */
   welcomeMessage?: string;
-  /** Custom button text for popup/slider triggers */
-  buttonText?: string;
   /** Custom params to pass to the interview (for tracking/attribution) */
   params?: Record<string, string>;
   /** Brand colors to override Research settings */
@@ -160,6 +158,7 @@ export interface EmbedHandle {
         | "onAuth"
         | "channel"
         | "welcomeMessage"
+        | "disableClose"
       >
     >
   ) => void;
@@ -176,6 +175,15 @@ export interface EmbedHandle {
   readonly iframe: HTMLIFrameElement | null;
   /** @deprecated For legacy compatibility - may be null on server */
   readonly container: HTMLElement | null;
+}
+
+/** Internal handle for popup/slider with hide/show lifecycle (not re-exported from public entrypoint) */
+export interface ToggleableHandle extends EmbedHandle {
+  show: () => void;
+  hide: () => void;
+  canReuse: (config: EmbedConfig) => boolean;
+  replayOpenCallbacks: () => void;
+  readonly isOpen: boolean;
 }
 
 /** Handle for float bubble with open/close control (persistent UI element) */

--- a/packages/sdk/src/widget.test.ts
+++ b/packages/sdk/src/widget.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createWidget } from "./widget";
 import * as config from "./config";
 import * as iframe from "./iframe";
+import { MESSAGE_TYPES } from "./constants";
+import * as timing from "./timing";
 
 describe("createWidget", () => {
   let container: HTMLDivElement;
@@ -39,6 +41,18 @@ describe("createWidget", () => {
     expect(loading).toBeTruthy();
 
     handle.unmount();
+  });
+
+  it("removes the load timer on unmount", () => {
+    const removeTimerSpy = vi.spyOn(timing, "removeTimer");
+
+    const handle = createWidget(container, {
+      researchId: "test-research-id",
+    });
+
+    handle.unmount();
+
+    expect(removeTimerSpy).toHaveBeenCalledWith("test-research-id");
   });
 
   it("returns no-op handle when no DOM", () => {
@@ -350,6 +364,41 @@ describe("createWidget", () => {
       expect(fn3).toHaveBeenCalledTimes(1);
       expect(fn2).not.toHaveBeenCalled();
       expect(fn1).not.toHaveBeenCalled();
+
+      handle.unmount();
+    });
+
+    it("forwards auth-complete messages to onAuth", () => {
+      const onAuth = vi.fn();
+      const popupWindow = {} as Window;
+      vi.spyOn(window, "open").mockReturnValue(popupWindow);
+
+      const handle = createWidget(container, {
+        researchId,
+        host,
+        onAuth,
+      });
+
+      sendMessage(handle.iframe!, MESSAGE_TYPES.authRequest, {
+        provider: "google",
+        authUrl: `${host}/embed-auth/google`,
+      });
+
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: MESSAGE_TYPES.popupAuthComplete,
+            token: "test-token",
+          },
+          origin: host,
+          source: popupWindow,
+        })
+      );
+
+      expect(onAuth).toHaveBeenCalledWith({
+        researchId,
+        token: "test-token",
+      });
 
       handle.unmount();
     });

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -13,6 +13,7 @@ import {
 } from "./iframe";
 import { createLoadingIndicator } from "./loading";
 import { injectStyles } from "./styles";
+import { removeTimer } from "./timing";
 import { cn, getThemeClass } from "./utils";
 
 type WidgetResources = {
@@ -154,6 +155,9 @@ export function createWidget(
       get onError() {
         return currentConfig.onError;
       },
+      get onAuth() {
+        return currentConfig.onAuth;
+      },
     },
     iframe,
     host,
@@ -178,6 +182,7 @@ export function createWidget(
     cleanup();
     unregisterIframe();
     widgetResources.delete(iframe);
+    removeTimer(researchId);
     wrapper.remove();
   };
 


### PR DESCRIPTION
## Summary

- **Hide-on-close**: popup/slider close now hides the overlay (`display:none`) instead of destroying the iframe, so reopening is instant with conversation state preserved via iframe sessionStorage
- **Iframe preloading**: button-triggered and auto-triggered embeds (timeout/exit-intent) preload a hidden iframe during idle time (`requestIdleCallback`) so the embed is warm when opened
- **Resource hints**: inject `preconnect`/`dns-prefetch` for the embed host on SDK load to warm DNS/TLS early
- **Embed timing instrumentation**: dev-only `EmbedTimer` for load waterfall debugging (to be stripped before shipping)
- **Removed `injectPrefetchHint`**: was broken when iframe URL had additional query params beyond `?embed=true`

## Test plan

- [x] `pnpm test` — 323 tests pass
- [x] `pnpm build` — no type errors
- [ ] Manual: button popup open → close → reopen should be instant (no spinner)
- [ ] Manual: auto-trigger popup with `timeout:5000` should open instantly when timer fires
- [ ] Manual: `Perspective.destroyAll()` still fully cleans up DOM
- [ ] Manual: page navigation (MPA) → SDK re-inits → preload fires again with browser-cached assets