### PR TITLE
fix: remove footer hint skeleton from loading indicator

### DIFF
--- a/.changeset/whole-owls-find.md
+++ b/.changeset/whole-owls-find.md
@@ -1,0 +1,6 @@
+---
+"@perspective-ai/sdk": patch
+"@perspective-ai/sdk-react": patch
+---
+
+Remove footer hint skeleton from the loading indicator

--- a/packages/sdk/src/loading.test.ts
+++ b/packages/sdk/src/loading.test.ts
@@ -48,10 +48,10 @@ describe("createLoadingIndicator", () => {
     expect(pill.style.borderRadius).toBe("9999px");
   });
 
-  it("renders footer hint line", () => {
+  it("does not render footer hint line", () => {
     const el = createLoadingIndicator();
     const footer = el.children[4] as HTMLElement;
-    expect(footer).toBeTruthy();
+    expect(footer).toBeFalsy();
   });
 
   it("shimmer elements have animation applied", () => {

--- a/packages/sdk/src/loading.ts
+++ b/packages/sdk/src/loading.ts
@@ -199,9 +199,9 @@ export function createLoadingIndicator(options?: LoadingOptions): HTMLElement {
   container.appendChild(inputArea);
 
   // -- Footer: centered hint text --
-  const footer = shimmer("14rem", "0.75rem");
-  footer.style.margin = "0.75rem auto 0";
-  container.appendChild(footer);
+  // const footer = shimmer("14rem", "0.75rem");
+  // footer.style.margin = "0.75rem auto 0";
+  // container.appendChild(footer);
 
   return container;
 }


### PR DESCRIPTION
## What's Changed

The loading indicator's footer hint skeleton didn't match the actual embed layout, so it's been removed.

**Loading Indicator**
- Commented out the shimmer footer hint element in `createLoadingIndicator`
- Updated test to assert the footer is no longer rendered
