### PR TITLE
fix: align JSON-LD description with main app schema

### DIFF
--- a/.changeset/fix-jsonld-description.md
+++ b/.changeset/fix-jsonld-description.md
@@ -1,0 +1,6 @@
+---
+"@perspective-ai/sdk": patch
+"@perspective-ai/sdk-react": patch
+---
+
+Align JSON-LD SoftwareApplication description with the main app's schema

--- a/packages/sdk-react/src/DiscoveryMetadata.tsx
+++ b/packages/sdk-react/src/DiscoveryMetadata.tsx
@@ -40,7 +40,8 @@ export function DiscoveryMetadata({ version }: DiscoveryMetadataProps) {
         "@type": "SoftwareApplication",
         "@id": `${PERSPECTIVE_URL}/#widget`,
         name: "Perspective AI",
-        description: "AI-powered customer research interview widget",
+        description:
+          "Rigid forms cause drop-off, weaken qualification, and strip away context. Perspective uses adaptive AI to turn forms into conversations that capture structured data and trigger automation.",
         url: PERSPECTIVE_URL,
         applicationCategory: "BusinessApplication",
         softwareVersion: version ?? SDK_VERSION,

--- a/packages/sdk/src/attribution.ts
+++ b/packages/sdk/src/attribution.ts
@@ -24,7 +24,8 @@ const JSON_LD = {
       "@type": "SoftwareApplication",
       "@id": `${PERSPECTIVE_URL}/#widget`,
       name: "Perspective AI",
-      description: "AI-powered customer research interview widget",
+      description:
+        "Rigid forms cause drop-off, weaken qualification, and strip away context. Perspective uses adaptive AI to turn forms into conversations that capture structured data and trigger automation.",
       url: PERSPECTIVE_URL,
       applicationCategory: "BusinessApplication",
       softwareVersion: SDK_VERSION,


### PR DESCRIPTION
## Summary

- Align the JSON-LD `SoftwareApplication` description in both `@perspective-ai/sdk` and `@perspective-ai/sdk-react` with the main app's homepage schema from PR #3824

## Test plan
- [x] All 384 SDK + 89 React tests pass