### PR TITLE
feat: add perspective:visual-ready event for faster skeleton hide

### DIFF
--- a/.changeset/skip-config-fetch-non-float.md
+++ b/.changeset/skip-config-fetch-non-float.md
@@ -1,0 +1,11 @@
+---
+"@perspective-ai/sdk": minor
+"@perspective-ai/sdk-react": minor
+---
+
+Stop blocking iframe creation on the embed config API for non-float embed types. Workspace-level appearance overrides (`hideProgress`, `hideGreeting`, `hideBranding`, `enableFullScreen`) are now resolved by the iframe page server-side, eliminating a parent-side API round trip on every cold load — previously this added 90ms warm and up to ~2.7s on a cold lambda.
+
+- `Widget`, `createWidget`, `openPopup`, `openSlider`, `createFullpage` no longer call `fetchEmbedConfig` before creating the iframe. The iframe element is created synchronously and `createWidget`/etc. show their own skeleton while the iframe loads.
+- `createFloatBubble` still fetches config (needed for bubble avatar, color, channel, and launcher customization) but no longer applies `embedSettings.appearance` to the iframe URL — that's also iframe-side now.
+- `appearanceToParams` and the `appearanceOverrides` parameter on `createIframe` are removed (they were only used by the old appearance-via-URL path).
+- API config consumers can continue to read `embedSettings.appearance` from `/api/v1/embed/config` — the field stays in the response for backwards compatibility with older SDK versions in the wild, but new SDKs ignore it.

--- a/.changeset/visual-ready-event.md
+++ b/.changeset/visual-ready-event.md
@@ -1,0 +1,10 @@
+---
+"@perspective-ai/sdk": minor
+"@perspective-ai/sdk-react": minor
+---
+
+Hide the loading skeleton on a new `perspective:visual-ready` signal emitted by the iframe before React hydrates, instead of waiting for the post-hydration `perspective:ready`. The skeleton now disappears hundreds of milliseconds earlier on cold loads — the embed feels noticeably snappier, closer to a chat widget like Intercom.
+
+- New `MESSAGE_TYPES.visualReady` (`perspective:visual-ready`) constant exported alongside `ready`. The SDK listens for whichever arrives first and treats `ready` as a fallback for older iframe versions, so this is fully backwards compatible.
+- New optional `onVisualReady` callback on `EmbedConfig` for consumers who want to react to the early visual-ready signal. `onReady` continues to fire once the iframe is fully interactive and is still the right hook for most consumers.
+- Reduced the iframe fade-in / skeleton fade-out from 300ms to 150ms across `widget`, `popup`, `slider`, `fullpage`, and `float` — long fades made the embed feel slow even after content was ready.

--- a/packages/sdk-react/src/Widget.test.tsx
+++ b/packages/sdk-react/src/Widget.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@perspective-ai/sdk", () => ({
   }),
   perfLog: vi.fn(),
   isPerfDebug: vi.fn(() => false),
+  ensureHostPreconnect: vi.fn(),
 }));
 
 import { createWidget } from "@perspective-ai/sdk";

--- a/packages/sdk-react/src/Widget.test.tsx
+++ b/packages/sdk-react/src/Widget.test.tsx
@@ -110,16 +110,12 @@ describe("Widget", () => {
     expect(config.host).toBe("https://custom.example.com");
   });
 
-  it("shows skeleton immediately, creates widget after config loads", async () => {
+  it("creates widget immediately on mount (no upfront config fetch)", async () => {
     render(<Widget researchId="test-research-id" />);
-    // Skeleton shown instantly, widget not yet created
-    expect(mockCreateWidget).not.toHaveBeenCalled();
-    const container = screen.getByTestId("perspective-widget");
-    expect(container.querySelector(".perspective-loading")).toBeTruthy();
-
+    // Widget is created synchronously inside the mount effect — no upfront
+    // /api/v1/embed/config round-trip blocks iframe creation. createWidget
+    // renders its own skeleton internally while the iframe loads.
     await act(async () => {});
-
-    // After config loads, widget is created and skeleton removed
     expect(mockCreateWidget).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/sdk-react/src/Widget.test.tsx
+++ b/packages/sdk-react/src/Widget.test.tsx
@@ -29,6 +29,8 @@ vi.mock("@perspective-ai/sdk", () => ({
     el.className = "perspective-loading";
     return el;
   }),
+  perfLog: vi.fn(),
+  isPerfDebug: vi.fn(() => false),
 }));
 
 import { createWidget } from "@perspective-ai/sdk";

--- a/packages/sdk-react/src/Widget.test.tsx
+++ b/packages/sdk-react/src/Widget.test.tsx
@@ -87,6 +87,7 @@ describe("Widget", () => {
 
   it("calls createWidget with correct config", async () => {
     const onReady = vi.fn();
+    const onVisualReady = vi.fn();
     const onSubmit = vi.fn();
 
     render(
@@ -96,6 +97,7 @@ describe("Widget", () => {
         theme="dark"
         host="https://custom.example.com"
         onReady={onReady}
+        onVisualReady={onVisualReady}
         onSubmit={onSubmit}
       />
     );
@@ -108,6 +110,7 @@ describe("Widget", () => {
     expect(config.params).toEqual({ source: "test" });
     expect(config.theme).toBe("dark");
     expect(config.host).toBe("https://custom.example.com");
+    expect(config.onVisualReady).toBeTypeOf("function");
   });
 
   it("creates widget immediately on mount (no upfront config fetch)", async () => {

--- a/packages/sdk-react/src/Widget.tsx
+++ b/packages/sdk-react/src/Widget.tsx
@@ -10,6 +10,7 @@ import {
   createWidget,
   createLoadingIndicator,
   fetchEmbedConfig,
+  perfLog,
   type EmbedConfig,
   type EmbedHandle,
 } from "@perspective-ai/sdk";
@@ -58,6 +59,8 @@ export function Widget({
     const container = containerRef.current;
     if (!container) return;
 
+    perfLog("SDK-React", "Widget effect mounted", { researchId });
+
     // Show skeleton instantly while config fetches in parallel
     const skeleton = createLoadingIndicator({ theme, brand });
     skeleton.style.position = "relative";
@@ -66,7 +69,9 @@ export function Widget({
 
     let cancelled = false;
 
+    perfLog("SDK-React", "fetchEmbedConfig start", { researchId });
     fetchEmbedConfig(researchId, host).then((config) => {
+      perfLog("SDK-React", "fetchEmbedConfig done", { researchId });
       if (cancelled) return;
       skeleton.remove();
 

--- a/packages/sdk-react/src/Widget.tsx
+++ b/packages/sdk-react/src/Widget.tsx
@@ -8,8 +8,6 @@ import {
 import { DiscoveryMetadata } from "./DiscoveryMetadata";
 import {
   createWidget,
-  createLoadingIndicator,
-  fetchEmbedConfig,
   ensureHostPreconnect,
   perfLog,
   type EmbedConfig,
@@ -62,50 +60,33 @@ export function Widget({
 
     perfLog("SDK-React", "Widget effect mounted", { researchId });
 
-    // Warm DNS+TLS to the embed host as early as possible — saves 30-200ms
-    // on the upcoming config fetch and iframe HTTP request when the SDK is
-    // loaded via npm bundle (no prior network contact with the host).
+    // Warm DNS+TLS to the embed host as early as possible.
     ensureHostPreconnect(host);
 
-    // Show skeleton instantly while config fetches in parallel
-    const skeleton = createLoadingIndicator({ theme, brand });
-    skeleton.style.position = "relative";
-    skeleton.style.minHeight = "500px";
-    container.appendChild(skeleton);
-
-    let cancelled = false;
-
-    perfLog("SDK-React", "fetchEmbedConfig start", { researchId });
-    fetchEmbedConfig(researchId, host).then((config) => {
-      perfLog("SDK-React", "fetchEmbedConfig done", { researchId });
-      if (cancelled) return;
-      skeleton.remove();
-
-      const handle = createWidget(container, {
-        researchId,
-        params,
-        brand,
-        theme,
-        host,
-        disableJsonLdAttribution,
-        _apiConfig: config,
-        onReady: stableOnReady,
-        onSubmit: stableOnSubmit,
-        onNavigate: stableOnNavigate,
-        onClose: stableOnClose,
-        onError: stableOnError,
-      });
-
-      handleRef.current = handle;
-
-      if (embedRef) {
-        embedRef.current = handle;
-      }
+    // No upfront config fetch — the iframe resolves workspace-level
+    // appearance overrides server-side. createWidget renders its own
+    // skeleton while the iframe loads.
+    const handle = createWidget(container, {
+      researchId,
+      params,
+      brand,
+      theme,
+      host,
+      disableJsonLdAttribution,
+      onReady: stableOnReady,
+      onSubmit: stableOnSubmit,
+      onNavigate: stableOnNavigate,
+      onClose: stableOnClose,
+      onError: stableOnError,
     });
 
+    handleRef.current = handle;
+
+    if (embedRef) {
+      embedRef.current = handle;
+    }
+
     return () => {
-      cancelled = true;
-      skeleton.remove();
       if (handleRef.current) {
         handleRef.current.unmount();
         handleRef.current = null;

--- a/packages/sdk-react/src/Widget.tsx
+++ b/packages/sdk-react/src/Widget.tsx
@@ -10,6 +10,7 @@ import {
   createWidget,
   createLoadingIndicator,
   fetchEmbedConfig,
+  ensureHostPreconnect,
   perfLog,
   type EmbedConfig,
   type EmbedHandle,
@@ -60,6 +61,11 @@ export function Widget({
     if (!container) return;
 
     perfLog("SDK-React", "Widget effect mounted", { researchId });
+
+    // Warm DNS+TLS to the embed host as early as possible — saves 30-200ms
+    // on the upcoming config fetch and iframe HTTP request when the SDK is
+    // loaded via npm bundle (no prior network contact with the host).
+    ensureHostPreconnect(host);
 
     // Show skeleton instantly while config fetches in parallel
     const skeleton = createLoadingIndicator({ theme, brand });

--- a/packages/sdk-react/src/Widget.tsx
+++ b/packages/sdk-react/src/Widget.tsx
@@ -8,7 +8,6 @@ import {
 import { DiscoveryMetadata } from "./DiscoveryMetadata";
 import {
   createWidget,
-  ensureHostPreconnect,
   perfLog,
   type EmbedConfig,
   type EmbedHandle,
@@ -61,9 +60,6 @@ export function Widget({
     if (!container) return;
 
     perfLog("SDK-React", "Widget effect mounted", { researchId });
-
-    // Warm DNS+TLS to the embed host as early as possible.
-    ensureHostPreconnect(host);
 
     // No upfront config fetch — the iframe resolves workspace-level
     // appearance overrides server-side. createWidget renders its own

--- a/packages/sdk-react/src/Widget.tsx
+++ b/packages/sdk-react/src/Widget.tsx
@@ -35,6 +35,7 @@ export function Widget({
   host,
   disableJsonLdAttribution,
   onReady,
+  onVisualReady,
   onSubmit,
   onNavigate,
   onClose,
@@ -49,6 +50,7 @@ export function Widget({
 
   // Stable callbacks to avoid re-mounting on callback changes
   const stableOnReady = useStableCallback(onReady);
+  const stableOnVisualReady = useStableCallback(onVisualReady);
   const stableOnSubmit = useStableCallback(onSubmit);
   const stableOnNavigate = useStableCallback(onNavigate);
   const stableOnClose = useStableCallback(onClose);
@@ -74,6 +76,7 @@ export function Widget({
       host,
       disableJsonLdAttribution,
       onReady: stableOnReady,
+      onVisualReady: stableOnVisualReady,
       onSubmit: stableOnSubmit,
       onNavigate: stableOnNavigate,
       onClose: stableOnClose,
@@ -103,6 +106,7 @@ export function Widget({
     host,
     disableJsonLdAttribution,
     stableOnReady,
+    stableOnVisualReady,
     stableOnSubmit,
     stableOnNavigate,
     stableOnClose,

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -547,11 +547,16 @@ function autoInit(): void {
 
       if (autoOpenAttr) {
         if (persistedOpen === true) {
-          fetchConfig(researchId).then((config) => {
-            if (wasDestroyed(researchId, dg, ig)) return;
-            cachedConfig = config;
+          // Restore: popup was open on previous page. No need to await config —
+          // the iframe creation no longer reads _apiConfig (appearance overrides
+          // resolved server-side). Pre-fetch in parallel for downstream
+          // consumers that may still inspect cachedConfig.
+          if (!wasDestroyed(researchId, dg, ig)) {
+            fetchConfig(researchId).then((config) => {
+              if (!wasDestroyed(researchId, dg, ig)) cachedConfig = config;
+            });
             initPopup();
-          });
+          }
         } else if (persistedOpen !== false) {
           // Auto-open mode: trigger-based, no button styling
           try {
@@ -616,11 +621,11 @@ function autoInit(): void {
         if (persistedOpen === true) {
           triggerCleanups.get(researchId)?.();
           triggerCleanups.delete(researchId);
-          fetchConfig(researchId).then((config) => {
-            if (wasDestroyed(researchId, dg, ig)) return;
-            cachedConfig = config;
+          // Restore: same as the autoOpen case — don't await config; iframe
+          // creation doesn't need it.
+          if (!wasDestroyed(researchId, dg, ig)) {
             initPopup();
-          });
+          }
         }
       }
     });
@@ -683,11 +688,10 @@ function autoInit(): void {
         if (persistedOpen === true) {
           triggerCleanups.get(researchId)?.();
           triggerCleanups.delete(researchId);
-          fetchConfig(researchId).then((config) => {
-            if (wasDestroyed(researchId, dg, ig)) return;
-            sliderConfig = config;
+          // Restore: don't await config; iframe creation no longer needs it.
+          if (!wasDestroyed(researchId, dg, ig)) {
             initSlider();
-          });
+          }
         }
       }
     });

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -49,6 +49,9 @@ import { configure, getConfig, hasDom } from "./config";
 import { getPersistedOpenState } from "./state";
 import { resolveIsDark } from "./utils";
 import { injectGlobalMetadata } from "./attribution";
+import { perfLog } from "./perf";
+
+perfLog("SDK", "script evaluated");
 
 // Track all active instances
 const instances: Map<string, EmbedHandle | FloatHandle> = new Map();
@@ -456,6 +459,8 @@ function destroyAll(): void {
 function autoInit(): void {
   if (!hasDom()) return;
 
+  perfLog("SDK", "autoInit start");
+
   setupButtonThemeListener();
 
   // Widget embeds — skeleton immediately, config + iframe in parallel
@@ -466,6 +471,7 @@ function autoInit(): void {
       if (researchId && !instances.has(researchId)) {
         const params = parseParamsAttr(el);
         const brandConfig = extractBrandConfig(el);
+        perfLog("SDK", "autoInit found widget", { researchId });
         // Show skeleton instantly while config fetches
         const skeleton = createLoadingIndicator({
           theme: brandConfig.theme,
@@ -477,7 +483,9 @@ function autoInit(): void {
         const pending = { cancelled: false, skeleton };
         pendingInits.set(researchId, pending);
         // Config + mount in parallel — skeleton covers the wait
+        perfLog("SDK", "fetchConfig start", { researchId });
         fetchConfig(researchId).then((config) => {
+          perfLog("SDK", "fetchConfig done", { researchId });
           pendingInits.delete(researchId);
           skeleton.remove();
           // Bail if cancelled by destroy(), element removed, or instance exists
@@ -843,8 +851,19 @@ if (hasDom() && !window.__PERSPECTIVE_SDK_INITIALIZED__) {
   injectGlobalMetadata();
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", autoInit, { once: true });
+    perfLog("SDK", "waiting for DOMContentLoaded");
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        perfLog("SDK", "DOMContentLoaded fired");
+        autoInit();
+      },
+      { once: true }
+    );
   } else {
+    perfLog("SDK", "DOM already ready, autoInit immediately", {
+      readyState: document.readyState,
+    });
     autoInit();
   }
 

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -40,7 +40,6 @@ import {
   markShown,
 } from "./triggers";
 import { createWidget } from "./widget";
-import { createLoadingIndicator } from "./loading";
 import { openPopup } from "./popup";
 import { openSlider } from "./slider";
 import { createFloatBubble, createChatBubble } from "./float";
@@ -463,7 +462,10 @@ function autoInit(): void {
 
   setupButtonThemeListener();
 
-  // Widget embeds — skeleton immediately, config + iframe in parallel
+  // Widget embeds — mount immediately. The iframe resolves workspace-level
+  // appearance overrides server-side, so no API round-trip is needed before
+  // creating the iframe. createWidget renders its own skeleton internally
+  // while the iframe loads.
   document
     .querySelectorAll<HTMLElement>(`[${DATA_ATTRS.widget}]`)
     .forEach((el) => {
@@ -472,40 +474,19 @@ function autoInit(): void {
         const params = parseParamsAttr(el);
         const brandConfig = extractBrandConfig(el);
         perfLog("SDK", "autoInit found widget", { researchId });
-        // Show skeleton instantly while config fetches
-        const skeleton = createLoadingIndicator({
-          theme: brandConfig.theme,
-          brand: brandConfig.brand,
-        });
-        skeleton.style.position = "relative";
-        skeleton.style.minHeight = "500px";
-        el.appendChild(skeleton);
-        const pending = { cancelled: false, skeleton };
-        pendingInits.set(researchId, pending);
-        // Config + mount in parallel — skeleton covers the wait
-        perfLog("SDK", "fetchConfig start", { researchId });
-        fetchConfig(researchId).then((config) => {
-          perfLog("SDK", "fetchConfig done", { researchId });
-          pendingInits.delete(researchId);
-          skeleton.remove();
-          // Bail if cancelled by destroy(), element removed, or instance exists
-          if (pending.cancelled || !el.isConnected || instances.has(researchId))
-            return;
-          mount(el, {
-            researchId,
-            type: "widget",
-            params,
-            ...brandConfig,
-            disableJsonLdAttribution: el.hasAttribute(
-              DATA_ATTRS.disableJsonLdAttribution
-            ),
-            _apiConfig: config,
-          } as InternalEmbedConfig);
-        });
+        mount(el, {
+          researchId,
+          type: "widget",
+          params,
+          ...brandConfig,
+          disableJsonLdAttribution: el.hasAttribute(
+            DATA_ATTRS.disableJsonLdAttribution
+          ),
+        } as InternalEmbedConfig);
       }
     });
 
-  // Fullpage embeds — skeleton immediately, config + iframe in parallel
+  // Fullpage embeds — same: mount immediately, no upfront config fetch.
   document
     .querySelectorAll<HTMLElement>(`[${DATA_ATTRS.fullpage}]`)
     .forEach((el) => {
@@ -513,35 +494,15 @@ function autoInit(): void {
       if (researchId && !instances.has(researchId)) {
         const params = parseParamsAttr(el);
         const brandConfig = extractBrandConfig(el);
-        // Show skeleton instantly while config fetches
-        const skeleton = createLoadingIndicator({
-          theme: brandConfig.theme,
-          brand: brandConfig.brand,
-        });
-        skeleton.style.position = "fixed";
-        skeleton.style.inset = "0";
-        skeleton.style.zIndex = "2147483647";
-        document.body.appendChild(skeleton);
-        const pending = { cancelled: false, skeleton };
-        pendingInits.set(researchId, pending);
-        // Config + init in parallel — skeleton covers the wait
-        fetchConfig(researchId).then((config) => {
-          pendingInits.delete(researchId);
-          skeleton.remove();
-          // Bail if cancelled by destroy(), element removed, or instance exists
-          if (pending.cancelled || !el.isConnected || instances.has(researchId))
-            return;
-          init({
-            researchId,
-            type: "fullpage",
-            params,
-            ...brandConfig,
-            disableJsonLdAttribution: el.hasAttribute(
-              DATA_ATTRS.disableJsonLdAttribution
-            ),
-            _apiConfig: config,
-          } as InternalEmbedConfig);
-        });
+        init({
+          researchId,
+          type: "fullpage",
+          params,
+          ...brandConfig,
+          disableJsonLdAttribution: el.hasAttribute(
+            DATA_ATTRS.disableJsonLdAttribution
+          ),
+        } as InternalEmbedConfig);
       }
     });
 

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -107,6 +107,13 @@ export const MESSAGE_TYPES = {
   init: "perspective:init",
 
   // Iframe -> SDK
+  // visualReady: emitted as soon as the iframe document is parsed and painted,
+  // before React hydration. Used by the SDK to hide the loading skeleton with
+  // minimum perceived latency.
+  visualReady: "perspective:visual-ready",
+  // ready: emitted after the iframe app is fully hydrated and interactive.
+  // Used to fire the public `onReady` callback and run the SDK→iframe
+  // handshake (anonId, init, scrollbar styles, cached auth token).
   ready: "perspective:ready",
   resize: "perspective:resize",
   submit: "perspective:submit",

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -38,6 +38,7 @@ export const PARAM_KEYS = {
   embed: "embed",
   embedType: "embed_type",
   theme: "theme",
+  perfDebug: "perfDebug",
 } as const;
 
 export type ParamKey = (typeof PARAM_KEYS)[keyof typeof PARAM_KEYS];

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -473,22 +473,33 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
       overrides
     );
     iframe.style.opacity = "0";
-    iframe.style.transition = "opacity 0.3s ease";
+    iframe.style.transition = "opacity 0.15s ease";
 
     floatWindow.appendChild(closeBtn);
     floatWindow.appendChild(loading);
     floatWindow.appendChild(iframe);
     document.body.appendChild(floatWindow);
 
+    // See widget.ts — hide skeleton on first `visual-ready`, with `ready` fallback.
+    let skeletonHidden = false;
+    const hideSkeleton = () => {
+      if (skeletonHidden) return;
+      skeletonHidden = true;
+      loading.style.opacity = "0";
+      iframe!.style.opacity = "1";
+      setTimeout(() => loading.remove(), 150);
+    };
+
     // Set up message listener with loading state handling
     cleanup = setupMessageListener(
       researchId,
       {
+        get onVisualReady() {
+          return hideSkeleton;
+        },
         get onReady() {
           return () => {
-            loading.style.opacity = "0";
-            iframe!.style.opacity = "1";
-            setTimeout(() => loading.remove(), 300);
+            hideSkeleton();
             currentConfig.onReady?.();
           };
         },

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -13,7 +13,6 @@ import type {
 import { hasDom, getHost } from "./config";
 import {
   createIframe,
-  appearanceToParams,
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
@@ -462,18 +461,14 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
     });
     loading.style.borderRadius = "16px";
 
-    // Create iframe (hidden initially)
-    const overrides = appearanceToParams(
-      currentConfig._apiConfig?.embedSettings
-    );
+    // Create iframe (hidden initially). Appearance overrides resolved server-side.
     iframe = createIframe(
       researchId,
       "float",
       host,
       currentConfig.params,
       currentConfig.brand,
-      currentConfig.theme,
-      overrides
+      currentConfig.theme
     );
     iframe.style.opacity = "0";
     iframe.style.transition = "opacity 0.15s ease";

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -457,7 +457,6 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
     const loading = createLoadingIndicator({
       theme: currentConfig.theme,
       brand: currentConfig.brand,
-      appearance: currentConfig._apiConfig?.embedSettings?.appearance,
     });
     loading.style.borderRadius = "16px";
 

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -17,6 +17,7 @@ import {
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
+  ensureHostPreconnect,
 } from "./iframe";
 import { createLoadingIndicator } from "./loading";
 import { injectStyles, MIC_ICON, MESSAGES_ICON, CLOSE_ICON } from "./styles";
@@ -197,6 +198,7 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
   }
   const host = getHost(config.host);
 
+  ensureHostPreconnect(host);
   injectStyles();
   ensureGlobalListeners();
 

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -23,6 +23,7 @@ import { injectStyles, MIC_ICON, MESSAGES_ICON, CLOSE_ICON } from "./styles";
 import { getPersistedOpenState, setPersistedOpenState } from "./state";
 import { cn, getThemeClass, resolveIsDark } from "./utils";
 import { enrichContainer } from "./attribution";
+import { perfLog } from "./perf";
 
 /** Merge API launcher config over a base launcher (API is source of truth) */
 function mergeApiLauncher(
@@ -485,6 +486,7 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
     const hideSkeleton = () => {
       if (skeletonHidden) return;
       skeletonHidden = true;
+      perfLog("SDK", "skeleton hide started (float)", { researchId });
       loading.style.opacity = "0";
       iframe!.style.opacity = "1";
       setTimeout(() => loading.remove(), 150);

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -493,7 +493,10 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
       researchId,
       {
         get onVisualReady() {
-          return hideSkeleton;
+          return () => {
+            hideSkeleton();
+            currentConfig.onVisualReady?.();
+          };
         },
         get onReady() {
           return () => {

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -16,6 +16,7 @@ import { createLoadingIndicator } from "./loading";
 import { injectStyles } from "./styles";
 import { cn, getThemeClass } from "./utils";
 import { enrichContainer } from "./attribution";
+import { perfLog } from "./perf";
 
 function createNoOpHandle(researchId: string): EmbedHandle {
   return {
@@ -83,6 +84,7 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
   const hideSkeleton = () => {
     if (skeletonHidden) return;
     skeletonHidden = true;
+    perfLog("SDK", "skeleton hide started (fullpage)", { researchId });
     loading.style.opacity = "0";
     iframe.style.opacity = "1";
     setTimeout(() => loading.remove(), 150);

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -68,7 +68,7 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
     overrides
   );
   iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.3s ease";
+  iframe.style.transition = "opacity 0.15s ease";
 
   container.appendChild(iframe);
   document.body.appendChild(container);
@@ -77,6 +77,16 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
   // Mutable config reference for updates
   let currentConfig = { ...config };
   let messageCleanup: (() => void) | null = null;
+
+  // See widget.ts — hide skeleton on first `visual-ready`, with `ready` fallback.
+  let skeletonHidden = false;
+  const hideSkeleton = () => {
+    if (skeletonHidden) return;
+    skeletonHidden = true;
+    loading.style.opacity = "0";
+    iframe.style.opacity = "1";
+    setTimeout(() => loading.remove(), 150);
+  };
 
   // Register iframe for theme change notifications
   const unregisterIframe = registerIframe(iframe, host);
@@ -92,11 +102,12 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
   messageCleanup = setupMessageListener(
     researchId,
     {
+      get onVisualReady() {
+        return hideSkeleton;
+      },
       get onReady() {
         return () => {
-          loading.style.opacity = "0";
-          iframe.style.opacity = "1";
-          setTimeout(() => loading.remove(), 300);
+          hideSkeleton();
           currentConfig.onReady?.();
         };
       },

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -7,7 +7,6 @@ import type { EmbedHandle, InternalEmbedConfig } from "./types";
 import { hasDom, getHost } from "./config";
 import {
   createIframe,
-  appearanceToParams,
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
@@ -59,16 +58,14 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
   });
   container.appendChild(loading);
 
-  // Create iframe (hidden initially)
-  const overrides = appearanceToParams(config._apiConfig?.embedSettings);
+  // Create iframe (hidden initially). Appearance overrides resolved server-side.
   const iframe = createIframe(
     researchId,
     "fullpage",
     host,
     config.params,
     config.brand,
-    config.theme,
-    overrides
+    config.theme
   );
   iframe.style.opacity = "0";
   iframe.style.transition = "opacity 0.15s ease";

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -54,7 +54,6 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
-    appearance: config._apiConfig?.embedSettings?.appearance,
   });
   container.appendChild(loading);
 

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -11,6 +11,7 @@ import {
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
+  ensureHostPreconnect,
 } from "./iframe";
 import { createLoadingIndicator } from "./loading";
 import { injectStyles } from "./styles";
@@ -39,6 +40,7 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
   }
   const host = getHost(config.host);
 
+  ensureHostPreconnect(host);
   injectStyles();
   ensureGlobalListeners();
 

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -103,7 +103,10 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
     researchId,
     {
       get onVisualReady() {
-        return hideSkeleton;
+        return () => {
+          hideSkeleton();
+          currentConfig.onVisualReady?.();
+        };
       },
       get onReady() {
         return () => {

--- a/packages/sdk/src/iframe.test.ts
+++ b/packages/sdk/src/iframe.test.ts
@@ -332,6 +332,30 @@ describe("setupMessageListener", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("calls onVisualReady without running the ready handshake", () => {
+    const onVisualReady = vi.fn();
+    const onReady = vi.fn();
+    const postMessageSpy = vi.spyOn(iframe.contentWindow!, "postMessage");
+    removeListener = setupMessageListener(
+      researchId,
+      { onVisualReady, onReady },
+      iframe,
+      host
+    );
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: MESSAGE_TYPES.visualReady, researchId },
+        origin: host,
+        source: iframe.contentWindow,
+      })
+    );
+
+    expect(onVisualReady).toHaveBeenCalledTimes(1);
+    expect(onReady).not.toHaveBeenCalled();
+    expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+
   it("calls onError for error messages", () => {
     const onError = vi.fn();
     removeListener = setupMessageListener(

--- a/packages/sdk/src/iframe.test.ts
+++ b/packages/sdk/src/iframe.test.ts
@@ -5,6 +5,7 @@ import {
   sendMessage,
   registerIframe,
   notifyThemeChange,
+  ensureHostPreconnect,
 } from "./iframe";
 import { MESSAGE_TYPES, PARAM_KEYS, PARAM_VALUES } from "./constants";
 
@@ -500,6 +501,35 @@ describe("sendMessage", () => {
         type: "test",
       })
     ).not.toThrow();
+  });
+});
+
+describe("ensureHostPreconnect", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries when preconnect insertion fails before marking a host complete", () => {
+    const host = "https://retry-preconnect.example.com";
+    const appendSpy = vi
+      .spyOn(document.head, "appendChild")
+      .mockImplementation(() => {
+        throw new Error("head unavailable");
+      });
+
+    expect(() => ensureHostPreconnect(host)).not.toThrow();
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    appendSpy.mockRestore();
+
+    ensureHostPreconnect(host);
+
+    const links = Array.from(document.head.querySelectorAll("link")).filter(
+      (link) => link.getAttribute("href") === host
+    );
+    expect(links.map((link) => link.getAttribute("rel")).sort()).toEqual([
+      "dns-prefetch",
+      "preconnect",
+    ]);
   });
 });
 

--- a/packages/sdk/src/iframe.test.ts
+++ b/packages/sdk/src/iframe.test.ts
@@ -94,7 +94,7 @@ describe("createIframe", () => {
     Object.defineProperty(window, "location", {
       value: {
         ...originalLocation,
-        search: "?embed=false&theme=dark&ref=test",
+        search: "?embed=false&theme=dark&perfDebug=0&ref=test",
       },
       writable: true,
       configurable: true,
@@ -109,6 +109,7 @@ describe("createIframe", () => {
     const src = new URL(iframe.src);
     // Reserved params should be set by SDK, not from parent URL
     expect(src.searchParams.get(PARAM_KEYS.embed)).toBe("true");
+    expect(src.searchParams.has(PARAM_KEYS.perfDebug)).toBe(false);
     // Non-reserved params should be forwarded
     expect(src.searchParams.get("ref")).toBe("test");
 
@@ -117,6 +118,26 @@ describe("createIframe", () => {
       writable: true,
       configurable: true,
     });
+  });
+
+  it("forwards enabled perf debug after custom params", () => {
+    localStorage.setItem("perspective-perf-debug", "1");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const iframe = createIframe(
+        "test-research-id",
+        "widget",
+        "https://getperspective.ai",
+        { perfDebug: "0" }
+      );
+
+      const src = new URL(iframe.src);
+      expect(src.searchParams.get(PARAM_KEYS.perfDebug)).toBe("1");
+    } finally {
+      logSpy.mockRestore();
+      localStorage.removeItem("perspective-perf-debug");
+    }
   });
 
   it("custom params override parent URL params", () => {

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -8,7 +8,6 @@ import type {
   EmbedConfig,
   EmbedMessage,
   EmbedType,
-  ThemeConfig,
 } from "./types";
 import { hasDom, getHost } from "./config";
 import {
@@ -287,40 +286,13 @@ function buildIframeUrl(
   return url.toString();
 }
 
-/** Known appearance param keys — only these are allowed as overrides */
-const APPEARANCE_KEYS = new Set([
-  "hideProgress",
-  "hideGreeting",
-  "hideBranding",
-  "enableFullScreen",
-]);
-
-/** Convert embedSettings.appearance to URL query params. Emits both true/false so API can override embed code in either direction. */
-export function appearanceToParams(
-  embedSettings?: ThemeConfig["embedSettings"]
-): Record<string, string> | undefined {
-  const a = embedSettings?.appearance;
-  if (!a) return undefined;
-  const params: Record<string, string> = {};
-  if (a.hideProgress !== undefined)
-    params.hideProgress = a.hideProgress ? "true" : "false";
-  if (a.hideGreeting !== undefined)
-    params.hideGreeting = a.hideGreeting ? "true" : "false";
-  if (a.hideBranding !== undefined)
-    params.hideBranding = a.hideBranding ? "true" : "false";
-  if (a.enableFullScreen !== undefined)
-    params.enableFullScreen = a.enableFullScreen ? "true" : "false";
-  return Object.keys(params).length > 0 ? params : undefined;
-}
-
 export function createIframe(
   researchId: string,
   type: EmbedType,
   host: string,
   params?: Record<string, string>,
   brand?: { light?: BrandColors; dark?: BrandColors },
-  themeOverride?: "dark" | "light" | "system",
-  appearanceOverrides?: Record<string, string>
+  themeOverride?: "dark" | "light" | "system"
 ): HTMLIFrameElement {
   if (!hasDom()) {
     // Return a stub for SSR
@@ -336,18 +308,6 @@ export function createIframe(
     brand,
     themeOverride
   );
-
-  // Apply appearance overrides from API config (API wins over embed code)
-  // Restricted to APPEARANCE_KEYS to prevent overwriting reserved params
-  if (appearanceOverrides && Object.keys(appearanceOverrides).length > 0) {
-    const url = new URL(iframe.src);
-    for (const [key, value] of Object.entries(appearanceOverrides)) {
-      if (APPEARANCE_KEYS.has(key)) {
-        url.searchParams.set(key, value);
-      }
-    }
-    iframe.src = url.toString();
-  }
 
   iframe.setAttribute("allow", "microphone; camera");
   iframe.setAttribute("allowfullscreen", "true");

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -348,6 +348,15 @@ export function setupMessageListener(
     }
 
     switch (event.data.type) {
+      case MESSAGE_TYPES.visualReady: {
+        // Fired from the iframe's inline boot script before React hydrates.
+        // Used to hide the loading skeleton with minimum perceived latency.
+        // Idempotent: app may also send `ready` later, embeds hide the skeleton
+        // on whichever arrives first (older app versions only send `ready`).
+        config.onVisualReady?.();
+        break;
+      }
+
       case MESSAGE_TYPES.ready: {
         // Send scrollbar styles when iframe is ready
         sendScrollbarStyles(iframe, host);

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -24,6 +24,7 @@ import {
   ERROR_CODES,
 } from "./constants";
 import { normalizeHex } from "./utils";
+import { isPerfDebug, perfLog } from "./perf";
 
 /** Validate redirect URL - allow https, http localhost, and relative URLs */
 function isAllowedRedirectUrl(url: string): boolean {
@@ -211,6 +212,11 @@ function buildIframeUrl(
     url.searchParams.set(key, value);
   }
 
+  // Forward perf debug flag so the iframe-side logs activate too
+  if (isPerfDebug()) {
+    url.searchParams.set("perfDebug", "1");
+  }
+
   // Helper to set param only if color is valid
   const setColor = (key: string, color: string | undefined) => {
     if (!color) return;
@@ -318,6 +324,15 @@ export function createIframe(
   iframe.setAttribute("title", "Powered by Perspective AI concierge");
   iframe.style.cssText = "border:none;";
 
+  perfLog("SDK", "iframe element created (src set)", { researchId, type });
+  if (isPerfDebug()) {
+    iframe.addEventListener(
+      "load",
+      () => perfLog("SDK", "iframe.onload fired", { researchId, type }),
+      { once: true }
+    );
+  }
+
   return iframe;
 }
 
@@ -353,11 +368,13 @@ export function setupMessageListener(
         // Used to hide the loading skeleton with minimum perceived latency.
         // Idempotent: app may also send `ready` later, embeds hide the skeleton
         // on whichever arrives first (older app versions only send `ready`).
+        perfLog("SDK", "visual-ready received", { researchId });
         config.onVisualReady?.();
         break;
       }
 
       case MESSAGE_TYPES.ready: {
+        perfLog("SDK", "ready received", { researchId });
         // Send scrollbar styles when iframe is ready
         sendScrollbarStyles(iframe, host);
         // Send anon_id for anonymous auth

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -10,7 +10,7 @@ import type {
   EmbedType,
   ThemeConfig,
 } from "./types";
-import { hasDom } from "./config";
+import { hasDom, getHost } from "./config";
 import {
   RESERVED_PARAMS,
   PARAM_KEYS,
@@ -25,6 +25,41 @@ import {
 } from "./constants";
 import { normalizeHex } from "./utils";
 import { isPerfDebug, perfLog } from "./perf";
+
+// ---------------------------------------------------------------------------
+// Host preconnect — warm DNS + TLS to the embed host before the iframe HTTP
+// request fires. Useful when the SDK is loaded via npm/bundle (no prior
+// network contact with the host); a no-op in practice for CDN script-tag
+// integrations where the SDK script itself already established the connection.
+// Idempotent per host.
+// ---------------------------------------------------------------------------
+
+const preconnectedHosts = new Set<string>();
+
+export function ensureHostPreconnect(host?: string): void {
+  if (!hasDom()) return;
+  const resolved = getHost(host);
+  if (preconnectedHosts.has(resolved)) return;
+  preconnectedHosts.add(resolved);
+
+  try {
+    const preconnect = document.createElement("link");
+    preconnect.rel = "preconnect";
+    preconnect.href = resolved;
+    preconnect.crossOrigin = "anonymous";
+    document.head.appendChild(preconnect);
+
+    // dns-prefetch as a fallback hint for older browsers / certain proxies.
+    const dnsPrefetch = document.createElement("link");
+    dnsPrefetch.rel = "dns-prefetch";
+    dnsPrefetch.href = resolved;
+    document.head.appendChild(dnsPrefetch);
+
+    perfLog("SDK", "preconnect injected", { host: resolved });
+  } catch {
+    /* head not available — extremely rare */
+  }
+}
 
 /** Validate redirect URL - allow https, http localhost, and relative URLs */
 function isAllowedRedirectUrl(url: string): boolean {

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -39,7 +39,6 @@ export function ensureHostPreconnect(host?: string): void {
   if (!hasDom()) return;
   const resolved = getHost(host);
   if (preconnectedHosts.has(resolved)) return;
-  preconnectedHosts.add(resolved);
 
   try {
     const preconnect = document.createElement("link");
@@ -54,6 +53,7 @@ export function ensureHostPreconnect(host?: string): void {
     dnsPrefetch.href = resolved;
     document.head.appendChild(dnsPrefetch);
 
+    preconnectedHosts.add(resolved);
     perfLog("SDK", "preconnect injected", { host: resolved });
   } catch {
     /* head not available — extremely rare */

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -246,11 +246,6 @@ function buildIframeUrl(
     url.searchParams.set(key, value);
   }
 
-  // Forward perf debug flag so the iframe-side logs activate too
-  if (isPerfDebug()) {
-    url.searchParams.set("perfDebug", "1");
-  }
-
   // Helper to set param only if color is valid
   const setColor = (key: string, color: string | undefined) => {
     if (!color) return;
@@ -281,6 +276,11 @@ function buildIframeUrl(
         url.searchParams.set(key, value);
       }
     }
+  }
+
+  // Forward perf debug last so parent/custom params cannot disable it.
+  if (isPerfDebug()) {
+    url.searchParams.set(PARAM_KEYS.perfDebug, "1");
   }
 
   return url.toString();

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -86,3 +86,6 @@ export {
 } from "./constants";
 
 export type { ThemeValue, ParamKey, BrandKey, MessageType } from "./constants";
+
+// Perf instrumentation (opt-in via localStorage / URL param — no-op when off)
+export { perfLog, isPerfDebug } from "./perf";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,6 +44,9 @@ export { configure, getConfig } from "./config";
 export { fetchEmbedConfig } from "./embed-api";
 export { getPersistedOpenState } from "./state";
 
+// Network hints
+export { ensureHostPreconnect } from "./iframe";
+
 // Attribution / AEO signals
 export {
   injectJsonLd,

--- a/packages/sdk/src/perf.test.ts
+++ b/packages/sdk/src/perf.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { isPerfDebug } from "./perf";
+
+describe("isPerfDebug", () => {
+  afterEach(() => {
+    localStorage.removeItem("perspective-perf-debug");
+  });
+
+  it("reflects a localStorage toggle after an initial disabled check", () => {
+    localStorage.removeItem("perspective-perf-debug");
+
+    expect(isPerfDebug()).toBe(false);
+
+    localStorage.setItem("perspective-perf-debug", "1");
+
+    expect(isPerfDebug()).toBe(true);
+  });
+});

--- a/packages/sdk/src/perf.ts
+++ b/packages/sdk/src/perf.ts
@@ -1,0 +1,54 @@
+/**
+ * Opt-in performance instrumentation.
+ *
+ * Logs are off by default — enable via either of:
+ *   - `localStorage.setItem("perspective-perf-debug", "1")` in the browser console
+ *   - URL param `?perfDebug=1` on the parent page (auto-forwarded to the iframe)
+ *
+ * Each log line carries `perf.now()` (ms since this page's nav start) AND
+ * `Date.now()` (wall-clock) so the parent's and iframe's logs can be
+ * correlated across origins by absolute time.
+ */
+import { hasDom } from "./config";
+
+const PERF_DEBUG_LS_KEY = "perspective-perf-debug";
+const PERF_DEBUG_URL_PARAM = "perfDebug";
+
+let cached: boolean | null = null;
+
+export function isPerfDebug(): boolean {
+  if (cached !== null) return cached;
+  if (!hasDom()) {
+    cached = false;
+    return false;
+  }
+  try {
+    const fromLs = localStorage.getItem(PERF_DEBUG_LS_KEY) === "1";
+    const fromUrl =
+      new URLSearchParams(window.location.search).get(PERF_DEBUG_URL_PARAM) ===
+      "1";
+    cached = fromLs || fromUrl;
+  } catch {
+    cached = false;
+  }
+  return cached;
+}
+
+/** Scope label — `"SDK"` and `"SDK-React"` for the embed runtime, `"iframe"` for the embedded interview app. */
+export type PerfScope = "SDK" | "SDK-React" | "iframe" | (string & {});
+
+/** Cheap no-op when disabled. */
+export function perfLog(
+  scope: PerfScope,
+  label: string,
+  extra?: Record<string, unknown>
+): void {
+  if (!isPerfDebug() || !hasDom()) return;
+  const navMs = Math.round(performance.now());
+  // eslint-disable-next-line no-console
+  console.log(`[Perspective Perf ${scope}] ${label}`, {
+    "+nav (ms)": navMs,
+    wallMs: Date.now(),
+    ...extra,
+  });
+}

--- a/packages/sdk/src/perf.ts
+++ b/packages/sdk/src/perf.ts
@@ -14,24 +14,17 @@ import { hasDom } from "./config";
 const PERF_DEBUG_LS_KEY = "perspective-perf-debug";
 const PERF_DEBUG_URL_PARAM = "perfDebug";
 
-let cached: boolean | null = null;
-
 export function isPerfDebug(): boolean {
-  if (cached !== null) return cached;
-  if (!hasDom()) {
-    cached = false;
-    return false;
-  }
+  if (!hasDom()) return false;
   try {
     const fromLs = localStorage.getItem(PERF_DEBUG_LS_KEY) === "1";
     const fromUrl =
       new URLSearchParams(window.location.search).get(PERF_DEBUG_URL_PARAM) ===
       "1";
-    cached = fromLs || fromUrl;
+    return fromLs || fromUrl;
   } catch {
-    cached = false;
+    return false;
   }
-  return cached;
 }
 
 /** Scope label — `"SDK"` and `"SDK-React"` for the embed runtime, `"iframe"` for the embedded interview app. */

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -17,6 +17,7 @@ import { injectStyles, CLOSE_ICON } from "./styles";
 import { setPersistedOpenState } from "./state";
 import { cn, getThemeClass } from "./utils";
 import { enrichContainer } from "./attribution";
+import { perfLog } from "./perf";
 
 function createNoOpHandle(researchId: string): EmbedHandle {
   return {
@@ -101,6 +102,7 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
   const hideSkeleton = () => {
     if (skeletonHidden) return;
     skeletonHidden = true;
+    perfLog("SDK", "skeleton hide started (popup)", { researchId });
     loading.style.opacity = "0";
     iframe.style.opacity = "1";
     setTimeout(() => loading.remove(), 150);

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -11,6 +11,7 @@ import {
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
+  ensureHostPreconnect,
 } from "./iframe";
 import { createLoadingIndicator } from "./loading";
 import { injectStyles, CLOSE_ICON } from "./styles";
@@ -40,6 +41,7 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
   }
   const host = getHost(config.host);
 
+  ensureHostPreconnect(host);
   injectStyles();
   ensureGlobalListeners();
 

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -7,7 +7,6 @@ import type { EmbedHandle, InternalEmbedConfig } from "./types";
 import { hasDom, getHost } from "./config";
 import {
   createIframe,
-  appearanceToParams,
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
@@ -73,16 +72,14 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
   });
   loading.style.borderRadius = "16px";
 
-  // Create iframe (hidden initially)
-  const overrides = appearanceToParams(config._apiConfig?.embedSettings);
+  // Create iframe (hidden initially). Appearance overrides resolved server-side.
   const iframe = createIframe(
     researchId,
     "popup",
     host,
     config.params,
     config.brand,
-    config.theme,
-    overrides
+    config.theme
   );
   iframe.style.opacity = "0";
   iframe.style.transition = "opacity 0.15s ease";

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -82,7 +82,7 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
     overrides
   );
   iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.3s ease";
+  iframe.style.transition = "opacity 0.15s ease";
 
   modal.appendChild(closeBtn);
   modal.appendChild(loading);
@@ -95,6 +95,16 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
   let currentConfig = { ...config };
   let isOpen = true;
   let messageCleanup: (() => void) | null = null;
+
+  // See widget.ts — hide skeleton on first `visual-ready`, with `ready` fallback.
+  let skeletonHidden = false;
+  const hideSkeleton = () => {
+    if (skeletonHidden) return;
+    skeletonHidden = true;
+    loading.style.opacity = "0";
+    iframe.style.opacity = "1";
+    setTimeout(() => loading.remove(), 150);
+  };
   const persistOpenState = (open: boolean) => {
     setPersistedOpenState({
       researchId,
@@ -132,11 +142,12 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
   messageCleanup = setupMessageListener(
     researchId,
     {
+      get onVisualReady() {
+        return hideSkeleton;
+      },
       get onReady() {
         return () => {
-          loading.style.opacity = "0";
-          iframe.style.opacity = "1";
-          setTimeout(() => loading.remove(), 300);
+          hideSkeleton();
           currentConfig.onReady?.();
         };
       },

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -64,11 +64,10 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
     closeBtn.style.display = "none";
   }
 
-  // Create loading indicator with theme and brand colors
+  // Create loading indicator with theme and brand colors.
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
-    appearance: config._apiConfig?.embedSettings?.appearance,
   });
   loading.style.borderRadius = "16px";
 

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -143,7 +143,10 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
     researchId,
     {
       get onVisualReady() {
-        return hideSkeleton;
+        return () => {
+          hideSkeleton();
+          currentConfig.onVisualReady?.();
+        };
       },
       get onReady() {
         return () => {

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -11,6 +11,7 @@ import {
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
+  ensureHostPreconnect,
 } from "./iframe";
 import { createLoadingIndicator } from "./loading";
 import { injectStyles, CLOSE_ICON } from "./styles";
@@ -40,6 +41,7 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
   }
   const host = getHost(config.host);
 
+  ensureHostPreconnect(host);
   injectStyles();
   ensureGlobalListeners();
 

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -7,7 +7,6 @@ import type { EmbedHandle, InternalEmbedConfig } from "./types";
 import { hasDom, getHost } from "./config";
 import {
   createIframe,
-  appearanceToParams,
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
@@ -75,16 +74,14 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
     appearance: config._apiConfig?.embedSettings?.appearance,
   });
 
-  // Create iframe (hidden initially)
-  const overrides = appearanceToParams(config._apiConfig?.embedSettings);
+  // Create iframe (hidden initially). Appearance overrides resolved server-side.
   const iframe = createIframe(
     researchId,
     "slider",
     host,
     config.params,
     config.brand,
-    config.theme,
-    overrides
+    config.theme
   );
   iframe.style.opacity = "0";
   iframe.style.transition = "opacity 0.15s ease";

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -84,7 +84,7 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
     overrides
   );
   iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.3s ease";
+  iframe.style.transition = "opacity 0.15s ease";
 
   slider.appendChild(closeBtn);
   slider.appendChild(loading);
@@ -97,6 +97,16 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
   let currentConfig = { ...config };
   let isOpen = true;
   let messageCleanup: (() => void) | null = null;
+
+  // See widget.ts — hide skeleton on first `visual-ready`, with `ready` fallback.
+  let skeletonHidden = false;
+  const hideSkeleton = () => {
+    if (skeletonHidden) return;
+    skeletonHidden = true;
+    loading.style.opacity = "0";
+    iframe.style.opacity = "1";
+    setTimeout(() => loading.remove(), 150);
+  };
   const persistOpenState = (open: boolean) => {
     setPersistedOpenState({
       researchId,
@@ -135,11 +145,12 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
   messageCleanup = setupMessageListener(
     researchId,
     {
+      get onVisualReady() {
+        return hideSkeleton;
+      },
       get onReady() {
         return () => {
-          loading.style.opacity = "0";
-          iframe.style.opacity = "1";
-          setTimeout(() => loading.remove(), 300);
+          hideSkeleton();
           currentConfig.onReady?.();
         };
       },

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -17,6 +17,7 @@ import { injectStyles, CLOSE_ICON } from "./styles";
 import { setPersistedOpenState } from "./state";
 import { cn, getThemeClass } from "./utils";
 import { enrichContainer } from "./attribution";
+import { perfLog } from "./perf";
 
 function createNoOpHandle(researchId: string): EmbedHandle {
   return {
@@ -103,6 +104,7 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
   const hideSkeleton = () => {
     if (skeletonHidden) return;
     skeletonHidden = true;
+    perfLog("SDK", "skeleton hide started (slider)", { researchId });
     loading.style.opacity = "0";
     iframe.style.opacity = "1";
     setTimeout(() => loading.remove(), 150);

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -71,7 +71,6 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
-    appearance: config._apiConfig?.embedSettings?.appearance,
   });
 
   // Create iframe (hidden initially). Appearance overrides resolved server-side.

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -146,7 +146,10 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
     researchId,
     {
       get onVisualReady() {
-        return hideSkeleton;
+        return () => {
+          hideSkeleton();
+          currentConfig.onVisualReady?.();
+        };
       },
       get onReady() {
         return () => {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -116,6 +116,8 @@ export interface EmbedConfig {
   disableJsonLdAttribution?: boolean;
   /** Customize the floating launcher button appearance. Only used for float-type embeds. */
   launcher?: LauncherConfig;
+  /** Callback when the iframe is visually painted but not yet hydrated. Fires significantly earlier than `onReady` — used internally by the SDK to hide the loading skeleton ASAP. Most consumers should use `onReady` instead. */
+  onVisualReady?: () => void;
   /** Callback when embed is ready */
   onReady?: () => void;
   /** Callback when interview is submitted/completed */
@@ -204,6 +206,7 @@ export interface InitMessage {
 
 /** Messages sent from iframe to SDK */
 export type EmbedMessage =
+  | { type: "perspective:visual-ready"; researchId: string }
   | { type: "perspective:ready"; researchId: string }
   | { type: "perspective:resize"; researchId: string; height: number }
   | { type: "perspective:submit"; researchId: string; data?: unknown }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -157,6 +157,7 @@ export interface EmbedHandle {
       Pick<
         EmbedConfig,
         | "onReady"
+        | "onVisualReady"
         | "onSubmit"
         | "onNavigate"
         | "onClose"

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -111,7 +111,6 @@ export function createWidget(
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
-    appearance: config._apiConfig?.embedSettings?.appearance,
   });
   wrapper.appendChild(loading);
 

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -11,6 +11,7 @@ import {
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
+  ensureHostPreconnect,
 } from "./iframe";
 import { createLoadingIndicator } from "./loading";
 import { injectStyles } from "./styles";
@@ -97,6 +98,7 @@ export function createWidget(
 
   const host = getHost(config.host);
 
+  ensureHostPreconnect(host);
   injectStyles();
   ensureGlobalListeners();
 

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -16,6 +16,7 @@ import { createLoadingIndicator } from "./loading";
 import { injectStyles } from "./styles";
 import { cn, getThemeClass } from "./utils";
 import { enrichContainer } from "./attribution";
+import { perfLog } from "./perf";
 
 type WidgetResources = {
   cleanup: () => void;
@@ -82,6 +83,8 @@ export function createWidget(
 ): EmbedHandle {
   const { researchId } = config;
 
+  perfLog("SDK", "createWidget called", { researchId });
+
   // SSR safety: return no-op handle
   if (!hasDom() || !container) {
     return createNoOpHandle(researchId, "widget");
@@ -142,6 +145,7 @@ export function createWidget(
   const hideSkeleton = () => {
     if (skeletonHidden) return;
     skeletonHidden = true;
+    perfLog("SDK", "skeleton hide started (widget)", { researchId });
     loading.style.opacity = "0";
     iframe.style.opacity = "1";
     setTimeout(() => loading.remove(), 150);

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -7,7 +7,6 @@ import type { EmbedHandle, InternalEmbedConfig } from "./types";
 import { hasDom, getHost } from "./config";
 import {
   createIframe,
-  appearanceToParams,
   setupMessageListener,
   registerIframe,
   ensureGlobalListeners,
@@ -116,16 +115,17 @@ export function createWidget(
   });
   wrapper.appendChild(loading);
 
-  // Create iframe (hidden initially)
-  const overrides = appearanceToParams(config._apiConfig?.embedSettings);
+  // Create iframe (hidden initially). Workspace-level appearance overrides
+  // (hideProgress / hideGreeting / hideBranding / enableFullScreen) are now
+  // resolved by the iframe page server-side, so the SDK doesn't need to
+  // fetch config or merge URL params before creating the iframe.
   const iframe = createIframe(
     researchId,
     "widget",
     host,
     config.params,
     config.brand,
-    config.theme,
-    overrides
+    config.theme
   );
   iframe.style.width = "100%";
   iframe.style.height = "100%";

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -126,7 +126,7 @@ export function createWidget(
   iframe.style.height = "100%";
   iframe.style.minHeight = "500px";
   iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.3s ease";
+  iframe.style.transition = "opacity 0.15s ease";
 
   wrapper.appendChild(iframe);
   container.appendChild(wrapper);
@@ -135,16 +135,28 @@ export function createWidget(
   // Mutable config reference for updates
   let currentConfig = { ...config };
 
+  // Hide skeleton on the FIRST signal of visual readiness — typically
+  // `perspective:visual-ready` (pre-hydration), with `perspective:ready`
+  // as a fallback for older iframe versions that don't emit visual-ready.
+  let skeletonHidden = false;
+  const hideSkeleton = () => {
+    if (skeletonHidden) return;
+    skeletonHidden = true;
+    loading.style.opacity = "0";
+    iframe.style.opacity = "1";
+    setTimeout(() => loading.remove(), 150);
+  };
+
   // Set up message listener with loading state handling
   const cleanup = setupMessageListener(
     researchId,
     {
+      get onVisualReady() {
+        return hideSkeleton;
+      },
       get onReady() {
         return () => {
-          // Hide loading, show iframe
-          loading.style.opacity = "0";
-          iframe.style.opacity = "1";
-          setTimeout(() => loading.remove(), 300);
+          hideSkeleton();
           currentConfig.onReady?.();
         };
       },

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -157,7 +157,10 @@ export function createWidget(
     researchId,
     {
       get onVisualReady() {
-        return hideSkeleton;
+        return () => {
+          hideSkeleton();
+          currentConfig.onVisualReady?.();
+        };
       },
       get onReady() {
         return () => {


### PR DESCRIPTION
## Why

Embed widget feels slow because the SDK keeps the loading skeleton up until the iframe sends `perspective:ready` — which is gated on full React hydration of the interview app inside the iframe. 

Profiling showed the skeleton was visible for `iframe TTFB + HTML download + JS download + hydration + 300ms cosmetic fade`. Most of that tail is hydration, plus a fixed 300ms fade *after* the content is technically ready.

## What

Introduce a new `perspective:visual-ready` postMessage that the iframe app emits from an inline boot script *before React hydrates* (after HTML parse + 2× rAF to confirm first paint). The SDK uses this signal to hide the skeleton instead of waiting for `ready`.

- New `MESSAGE_TYPES.visualReady` (`perspective:visual-ready`) constant
- New optional `onVisualReady` callback on `EmbedConfig` for consumers who want to react to the early signal. `onReady` continues to fire once the iframe is fully interactive — that's still the right hook for most consumers.
- Skeleton-hide is idempotent and fires on the **first** of `visual-ready` or `ready`. Older iframe versions that only emit `ready` keep working unchanged — fully backwards compatible.
- Reduced iframe fade-in / skeleton fade-out from `0.3s` → `0.15s` across `widget`, `popup`, `slider`, `fullpage`, `float`. 300ms fades made the embed feel slow even when content was ready.

The matching iframe-side change (the inline `VisualReadyBeacon` that emits `visual-ready`, plus parallel layout fetch + Suspense'd `hasResearchEnded`) lives in the main app — separate PR.

## Tests

```
Test Files  14 passed (14)
     Tests  384 passed (384)
```

Plus 89 `@perspective-ai/sdk-react` tests still pass.

## Snapshot

Snapshot release for testing locally before merge.
