### PR TITLE
SDK: trim brand tokens to primary + bg, fix brand-color contrast

### DIFF
--- a/.changeset/trim-brand-tokens.md
+++ b/.changeset/trim-brand-tokens.md
@@ -1,0 +1,15 @@
+---
+"@perspective-ai/sdk": minor
+"@perspective-ai/sdk-react": minor
+---
+
+Trim brand color overrides to `primary` + `bg` only
+
+The interview app no longer honors the `secondary` and `text` brand overrides and has rescoped `bg`, so the SDK no longer advertises or forwards them.
+
+- **`BrandColors`** now centers on `primary` and `bg`. The SDK no longer forwards `secondary` or `text` to the iframe.
+  - `primary` themes buttons, the progress bar, links, the mic, and focus rings.
+  - `bg` paints the interview background behind the card, shown only when no background scene is set.
+  - `secondary` and `text` remain on the type as `@deprecated` no-ops so existing TypeScript consumers don't break; they're ignored at runtime.
+
+This is non-breaking: the app gracefully ignores unknown `brand.*` params and already-deployed embeds keep working. Passing `secondary`/`text` is simply a no-op going forward.

--- a/.changeset/trim-brand-tokens.md
+++ b/.changeset/trim-brand-tokens.md
@@ -13,3 +13,5 @@ The interview app no longer honors the `secondary` and `text` brand overrides an
   - `secondary` and `text` remain on the type as `@deprecated` no-ops so existing TypeScript consumers don't break; they're ignored at runtime.
 
 This is non-breaking: the app gracefully ignores unknown `brand.*` params and already-deployed embeds keep working. Passing `secondary`/`text` is simply a no-op going forward.
+
+Also: SDK chrome that paints a brand color now derives a contrasting foreground from that color's WCAG luminance, so light brand colors no longer produce unreadable white-on-light content. This applies to the popup/slider **trigger button** text, the **float launcher** icon (both previously hard-coded to white), and the **loading skeleton** shimmer/border palette (now chosen from the actual `brand.bg` luminance rather than the theme, so a dark `brand.bg` under a light theme still shows visible shimmer). Each falls back to the previous behavior when the color isn't a parseable hex.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -130,10 +130,10 @@ interface EmbedConfig {
 }
 
 interface BrandColors {
-  primary?: string; // Primary brand color
-  secondary?: string; // Secondary brand color
-  bg?: string; // Background color
-  text?: string; // Text color
+  primary?: string; // Primary accent — buttons, progress bar, links, mic, focus rings
+  bg?: string; // Interview background behind the card, shown only when no background scene is set
+  secondary?: string; // @deprecated — ignored, no longer forwarded (no-op)
+  text?: string; // @deprecated — ignored, no longer forwarded (no-op)
 }
 ```
 

--- a/packages/sdk/e2e/fixtures/brand-contrast.html
+++ b/packages/sdk/e2e/fixtures/brand-contrast.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Perspective SDK — Trigger Button Brand Contrast</title>
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        margin: 0;
+        padding: 1.5rem;
+        background: #f5f5f7;
+        color: #111;
+      }
+      h1 {
+        font-size: 1.1rem;
+        margin: 0 0 0.25rem;
+      }
+      p.note {
+        margin: 0 0 1.25rem;
+        color: #555;
+        font-size: 0.85rem;
+        max-width: 760px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: 200px 1fr;
+        gap: 0.5rem 1rem;
+        align-items: center;
+        max-width: 600px;
+      }
+      .label {
+        font-family: ui-monospace, monospace;
+        font-size: 0.8rem;
+        color: #444;
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      Visual fixture for the SDK trigger-button foreground contrast.
+
+      Each button below opens a popup and is styled by the SDK's real
+      updateButtonTheme(): background = brand.primary, foreground = a readable
+      color chosen from that background's luminance (readableTextColor). Light
+      brand colors should get dark text, dark colors should get white text.
+
+      Serve and open it:  pnpm exec serve e2e/fixtures -l 3456
+      then visit http://localhost:3456/brand-contrast.html
+    -->
+    <h1>
+      SDK trigger button — foreground contrast across <code>brand.primary</code>
+    </h1>
+    <p class="note">
+      Buttons are styled by the live SDK. The text color is derived from the
+      brand background, so a light <code>primary</code> gets dark text instead
+      of unreadable white. (Uses a placeholder research id; clicking opens a
+      popup against the configured host.)
+    </p>
+
+    <div class="grid">
+      <div class="label">#7c3aed (default)</div>
+      <button
+        data-perspective-popup="brand-contrast-demo"
+        data-perspective-brand="primary=#7c3aed"
+      >
+        Start interview
+      </button>
+
+      <div class="label">#ffe066 (light yellow)</div>
+      <button
+        data-perspective-popup="brand-contrast-demo"
+        data-perspective-brand="primary=#ffe066"
+      >
+        Start interview
+      </button>
+
+      <div class="label">#00e0a4 (mint)</div>
+      <button
+        data-perspective-popup="brand-contrast-demo"
+        data-perspective-brand="primary=#00e0a4"
+      >
+        Start interview
+      </button>
+
+      <div class="label">#ffffff (white)</div>
+      <button
+        data-perspective-popup="brand-contrast-demo"
+        data-perspective-brand="primary=#ffffff"
+      >
+        Start interview
+      </button>
+
+      <div class="label">#111827 (near-black)</div>
+      <button
+        data-perspective-popup="brand-contrast-demo"
+        data-perspective-brand="primary=#111827"
+      >
+        Start interview
+      </button>
+
+      <div class="label">#e5e7eb (light gray)</div>
+      <button
+        data-perspective-popup="brand-contrast-demo"
+        data-perspective-brand="primary=#e5e7eb"
+      >
+        Start interview
+      </button>
+    </div>
+
+    <script src="/sdk/perspective.global.js"></script>
+  </body>
+</html>

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -46,7 +46,7 @@ import { createFloatBubble, createChatBubble } from "./float";
 import { createFullpage } from "./fullpage";
 import { configure, getConfig, hasDom } from "./config";
 import { getPersistedOpenState } from "./state";
-import { resolveIsDark } from "./utils";
+import { resolveIsDark, readableTextColor } from "./utils";
 import { injectGlobalMetadata } from "./attribution";
 import { perfLog } from "./perf";
 
@@ -161,7 +161,14 @@ function updateButtonTheme(el: HTMLElement, config: ButtonStyleConfig): void {
   const bg = isDark
     ? (brand?.dark?.primary ?? themeConfig.darkPrimaryColor)
     : (brand?.light?.primary ?? themeConfig.primaryColor);
-  const text = isDark ? themeConfig.darkTextColor : themeConfig.textColor;
+  // Choose a foreground that contrasts with the resolved background so a light
+  // brand.primary doesn't end up with unreadable white text. Falls back to the
+  // preconfigured text color when bg isn't a parseable hex (e.g. a CSS color
+  // string from server config) so existing themes keep their chosen color.
+  const configuredText = isDark
+    ? themeConfig.darkTextColor
+    : themeConfig.textColor;
+  const text = readableTextColor(bg) ?? configuredText;
 
   el.style.backgroundColor = bg;
   el.style.color = text;
@@ -753,6 +760,7 @@ function autoInit(): void {
               `0 6px 16px ${bg}80`
             );
             bubble.style.backgroundColor = bg;
+            bubble.style.color = readableTextColor(bg) ?? "#ffffff";
             bubble.style.boxShadow = `0 4px 12px ${bg}66`;
           }
         }

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -161,9 +161,7 @@ function updateButtonTheme(el: HTMLElement, config: ButtonStyleConfig): void {
   const bg = isDark
     ? (brand?.dark?.primary ?? themeConfig.darkPrimaryColor)
     : (brand?.light?.primary ?? themeConfig.primaryColor);
-  const text = isDark
-    ? (brand?.dark?.text ?? themeConfig.darkTextColor)
-    : (brand?.light?.text ?? themeConfig.textColor);
+  const text = isDark ? themeConfig.darkTextColor : themeConfig.textColor;
 
   el.style.backgroundColor = bg;
   el.style.color = text;
@@ -235,12 +233,7 @@ function parseBrandAttr(attrValue: string | null): BrandColors | undefined {
       const value = valueParts.join("=").trim();
       if (value) {
         const k = key.trim() as keyof BrandColors;
-        if (
-          k === "primary" ||
-          k === "secondary" ||
-          k === "bg" ||
-          k === "text"
-        ) {
+        if (k === "primary" || k === "bg") {
           colors[k] = value;
         }
       }

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -50,15 +50,11 @@ export type ParamKey = (typeof PARAM_KEYS)[keyof typeof PARAM_KEYS];
 export const BRAND_KEYS = {
   // Light mode
   primary: "brand.primary",
-  secondary: "brand.secondary",
   bg: "brand.bg",
-  text: "brand.text",
 
   // Dark mode
   darkPrimary: "brand.dark.primary",
-  darkSecondary: "brand.dark.secondary",
   darkBg: "brand.dark.bg",
-  darkText: "brand.dark.text",
 } as const;
 
 export type BrandKey = (typeof BRAND_KEYS)[keyof typeof BRAND_KEYS];

--- a/packages/sdk/src/float.test.ts
+++ b/packages/sdk/src/float.test.ts
@@ -673,6 +673,35 @@ describe("createFloatBubble", () => {
       handle.unmount();
     });
 
+    it("sets a readable icon color for a light brand.primary", () => {
+      const handle = createFloatBubble({
+        researchId: "test-research-id",
+        brand: { light: { primary: "#ffe066" } }, // light yellow
+      });
+
+      const bubble = document.querySelector(
+        ".perspective-float-bubble"
+      ) as HTMLButtonElement;
+      // Icon is currentColor; on a light bg it must be dark, not the default white
+      expect(bubble.style.color).toBe("#000000");
+
+      handle.unmount();
+    });
+
+    it("keeps white icon color for a dark brand.primary", () => {
+      const handle = createFloatBubble({
+        researchId: "test-research-id",
+        brand: { light: { primary: "#7c3aed" } }, // brand purple
+      });
+
+      const bubble = document.querySelector(
+        ".perspective-float-bubble"
+      ) as HTMLButtonElement;
+      expect(bubble.style.color).toBe("#ffffff");
+
+      handle.unmount();
+    });
+
     it("className is added to bubble classList", () => {
       const handle = createFloatBubble({
         researchId: "test-research-id",

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -21,7 +21,7 @@ import {
 import { createLoadingIndicator } from "./loading";
 import { injectStyles, MIC_ICON, MESSAGES_ICON, CLOSE_ICON } from "./styles";
 import { getPersistedOpenState, setPersistedOpenState } from "./state";
-import { cn, getThemeClass, resolveIsDark } from "./utils";
+import { cn, getThemeClass, resolveIsDark, readableTextColor } from "./utils";
 import { enrichContainer } from "./attribution";
 import { perfLog } from "./perf";
 
@@ -227,6 +227,9 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
       `0 6px 16px ${bg}80`
     );
     bubble.style.backgroundColor = bg;
+    // Keep the icon (currentColor) readable on a light brand.primary; the CSS
+    // default is white, so fall back to white when bg isn't a parseable hex.
+    bubble.style.color = readableTextColor(bg) ?? "#ffffff";
     bubble.style.boxShadow = `0 4px 12px ${bg}66`;
   }
 
@@ -614,6 +617,7 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
             `0 6px 16px ${bg}80`
           );
           bubble.style.backgroundColor = bg;
+          bubble.style.color = readableTextColor(bg) ?? "#ffffff";
           bubble.style.boxShadow = `0 4px 12px ${bg}66`;
         }
       }

--- a/packages/sdk/src/iframe.test.ts
+++ b/packages/sdk/src/iframe.test.ts
@@ -206,15 +206,16 @@ describe("createIframe", () => {
       "https://getperspective.ai",
       undefined,
       {
-        light: { primary: "#ff0000", secondary: "#00ff00" },
-        dark: { primary: "#0000ff" },
+        light: { primary: "#ff0000", bg: "#00ff00" },
+        dark: { primary: "#0000ff", bg: "#111111" },
       }
     );
 
     const src = new URL(iframe.src);
     expect(src.searchParams.get("brand.primary")).toBe("#ff0000");
-    expect(src.searchParams.get("brand.secondary")).toBe("#00ff00");
+    expect(src.searchParams.get("brand.bg")).toBe("#00ff00");
     expect(src.searchParams.get("brand.dark.primary")).toBe("#0000ff");
+    expect(src.searchParams.get("brand.dark.bg")).toBe("#111111");
   });
 
   it("sets sandbox attribute", () => {

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -256,17 +256,13 @@ function buildIframeUrl(
   // Add brand colors using short keys
   if (brand?.light) {
     setColor(BRAND_KEYS.primary, brand.light.primary);
-    setColor(BRAND_KEYS.secondary, brand.light.secondary);
     setColor(BRAND_KEYS.bg, brand.light.bg);
-    setColor(BRAND_KEYS.text, brand.light.text);
   }
 
   // Add dark mode brand colors
   if (brand?.dark) {
     setColor(BRAND_KEYS.darkPrimary, brand.dark.primary);
-    setColor(BRAND_KEYS.darkSecondary, brand.dark.secondary);
     setColor(BRAND_KEYS.darkBg, brand.dark.bg);
-    setColor(BRAND_KEYS.darkText, brand.dark.text);
   }
 
   // Add custom params, filtering out reserved keys

--- a/packages/sdk/src/loading.test.ts
+++ b/packages/sdk/src/loading.test.ts
@@ -78,6 +78,27 @@ describe("createLoadingIndicator", () => {
     expect(el.style.background).toBe("#1a3a2a");
   });
 
+  it("uses a dark shimmer/border palette for a dark brand bg under light theme", () => {
+    const el = createLoadingIndicator({
+      theme: "light",
+      brand: { light: { bg: "#0a0a0a" } }, // dark bg despite light theme
+    });
+    expect(el.style.background).toBe("#0a0a0a");
+    // Dark palette uses white-based translucent shimmer/borders so they stay visible
+    expect(el.innerHTML).toContain("rgba(255, 255, 255");
+    expect(el.innerHTML).not.toContain("rgba(0, 0, 0");
+  });
+
+  it("uses a light shimmer/border palette for a light brand bg under dark theme", () => {
+    const el = createLoadingIndicator({
+      theme: "dark",
+      brand: { dark: { bg: "#fafafa" } }, // light bg despite dark theme
+    });
+    expect(el.style.background).toBe("#fafafa");
+    expect(el.innerHTML).toContain("rgba(0, 0, 0");
+    expect(el.innerHTML).not.toContain("rgba(255, 255, 255");
+  });
+
   it("has column layout with padding", () => {
     const el = createLoadingIndicator();
     expect(el.style.flexDirection).toBe("column");

--- a/packages/sdk/src/loading.ts
+++ b/packages/sdk/src/loading.ts
@@ -10,7 +10,7 @@
 
 import type { BrandColors, ThemeValue } from "./types";
 import { hasDom } from "./config";
-import { resolveTheme } from "./utils";
+import { resolveTheme, readableTextColor } from "./utils";
 
 /** Default background + semi-transparent shimmer that works on any bg */
 const DEFAULT_COLORS = {
@@ -54,10 +54,18 @@ function getLoadingColors(options?: LoadingOptions): {
   const theme = resolveTheme(options?.theme);
   const isDark = theme === "dark";
   const brandColors = isDark ? options?.brand?.dark : options?.brand?.light;
-  const defaults = isDark ? DEFAULT_COLORS.dark : DEFAULT_COLORS.light;
+  const bg = brandColors?.bg;
+
+  // Choose the shimmer/border palette from the actual background luminance when
+  // a brand bg is set, so a dark brand.bg under a light theme (or vice versa)
+  // still gets visible shimmer and borders. readableTextColor returns white for
+  // dark backgrounds; fall back to the theme default for non-hex bg values.
+  const fg = bg ? readableTextColor(bg) : undefined;
+  const useDarkPalette = fg ? fg === "#ffffff" : isDark;
+  const defaults = useDarkPalette ? DEFAULT_COLORS.dark : DEFAULT_COLORS.light;
 
   return {
-    bg: brandColors?.bg || defaults.bg,
+    bg: bg || defaults.bg,
     shimmer: defaults.shimmer,
     shimmerHighlight: defaults.shimmerHighlight,
     border: defaults.border,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -44,13 +44,21 @@ export interface AutoOpenConfig {
 
 /** Brand colors that can be passed via embed code */
 export interface BrandColors {
-  /** Primary accent color (buttons, links, focus states) */
+  /** Primary accent color — themes buttons, progress bar, links, mic, and focus rings */
   primary?: string;
-  /** Secondary accent color */
-  secondary?: string;
-  /** Background color of the embed */
+  /** Interview background behind the card, shown only when no background scene is set */
   bg?: string;
-  /** Primary text color */
+  /**
+   * @deprecated No longer supported — ignored by the interview app and not
+   * forwarded by the SDK. Kept only to avoid breaking TypeScript consumers that
+   * still reference it. Use `primary`/`bg`; this field is a no-op.
+   */
+  secondary?: string;
+  /**
+   * @deprecated No longer supported — ignored by the interview app and not
+   * forwarded by the SDK. Kept only to avoid breaking TypeScript consumers that
+   * still reference it. Use `primary`/`bg`; this field is a no-op.
+   */
   text?: string;
 }
 

--- a/packages/sdk/src/utils.test.ts
+++ b/packages/sdk/src/utils.test.ts
@@ -6,6 +6,8 @@ import {
   resolveTheme,
   normalizeHex,
   hexToRgba,
+  relativeLuminance,
+  readableTextColor,
 } from "./utils";
 import * as config from "./config";
 
@@ -158,5 +160,46 @@ describe("hexToRgba", () => {
   it("returns default color for invalid hex", () => {
     expect(hexToRgba("invalid", 0.5)).toBe("rgba(118, 41, 200, 0.5)");
     expect(hexToRgba("#abc", 0.5)).toBe("rgba(118, 41, 200, 0.5)"); // 3-char hex not supported
+  });
+});
+
+describe("relativeLuminance", () => {
+  it("returns 0 for black and 1 for white", () => {
+    expect(relativeLuminance("#000000")).toBe(0);
+    expect(relativeLuminance("#ffffff")).toBeCloseTo(1, 5);
+  });
+
+  it("supports shorthand and alpha hex (alpha ignored)", () => {
+    expect(relativeLuminance("#fff")).toBeCloseTo(1, 5);
+    expect(relativeLuminance("#000000ff")).toBe(0);
+  });
+
+  it("returns undefined for unparseable input", () => {
+    expect(relativeLuminance("notacolor")).toBeUndefined();
+    expect(relativeLuminance("")).toBeUndefined();
+  });
+});
+
+describe("readableTextColor", () => {
+  it("uses black text on light backgrounds", () => {
+    expect(readableTextColor("#ffffff")).toBe("#000000");
+    expect(readableTextColor("#ffe066")).toBe("#000000"); // light yellow
+    expect(readableTextColor("#e5e7eb")).toBe("#000000"); // light gray
+  });
+
+  it("uses white text on dark backgrounds", () => {
+    expect(readableTextColor("#000000")).toBe("#ffffff");
+    expect(readableTextColor("#7c3aed")).toBe("#ffffff"); // brand purple
+    expect(readableTextColor("#111827")).toBe("#ffffff"); // near-black
+  });
+
+  it("accepts hex without leading # and shorthand", () => {
+    expect(readableTextColor("fff")).toBe("#000000");
+    expect(readableTextColor("000")).toBe("#ffffff");
+  });
+
+  it("returns undefined for unparseable input so callers can fall back", () => {
+    expect(readableTextColor("var(--brand)")).toBeUndefined();
+    expect(readableTextColor("")).toBeUndefined();
   });
 });

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -71,6 +71,64 @@ export function normalizeHex(color: string): string | undefined {
 }
 
 /**
+ * Strictly parse a hex color (#RGB / #RRGGBB / #RRGGBBAA, with or without a
+ * leading #) into 8-bit RGB channels. Returns undefined for anything that
+ * isn't a well-formed hex string — unlike normalizeHex, this does NOT try to
+ * salvage hex characters out of arbitrary input, so callers can reliably fall
+ * back when given a non-hex CSS color (e.g. "var(--brand)" or "rebeccapurple").
+ */
+function hexToRgb(
+  hex: string
+): { r: number; g: number; b: number } | undefined {
+  let h = hex.trim().replace(/^#/, "");
+  if (!/^(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(h)) {
+    return undefined;
+  }
+  // Expand shorthand (abc -> aabbcc)
+  if (h.length === 3) {
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  // Drop alpha if present (RRGGBBAA)
+  if (h.length === 8) h = h.slice(0, 6);
+
+  const n = parseInt(h, 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+/**
+ * WCAG relative luminance (0–1) of a hex color, or undefined if unparseable.
+ * https://www.w3.org/TR/WCAG20/#relativeluminancedef
+ */
+export function relativeLuminance(hex: string): number | undefined {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return undefined;
+
+  const channel = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return (
+    0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b)
+  );
+}
+
+/**
+ * Pick a readable foreground (`#000000` or `#ffffff`) for a given background
+ * color, based on its WCAG relative luminance. The ~0.179 threshold is the
+ * crossover where black vs. white text yield equal contrast ratios against the
+ * background. Returns undefined if the background isn't a parseable hex, so
+ * callers can fall back to a preconfigured color.
+ */
+export function readableTextColor(bgHex: string): string | undefined {
+  const luminance = relativeLuminance(bgHex);
+  if (luminance === undefined) return undefined;
+  return luminance > 0.179 ? "#000000" : "#ffffff";
+}
+
+/**
  * Convert hex to rgba for spinner track
  */
 export function hexToRgba(hex: string, alpha: number): string {


### PR DESCRIPTION
## Summary

Two related changes to the embed SDK's brand-color handling (minor bump for `@perspective-ai/sdk` + `@perspective-ai/sdk-react` via changeset).

### 1. Trim brand color overrides to `primary` + `bg`

The interview app no longer honors the `secondary` / `text` brand overrides and has rescoped `bg`, so the SDK was over-promising. Now `BrandColors` centers on:

- **`primary`** — buttons, progress bar, links, mic, focus rings.
- **`bg`** — interview background behind the card, shown only when no background scene is set.

`secondary` / `text` are no longer forwarded to the iframe, and are kept on the type as `@deprecated` no-ops so existing TypeScript consumers that reference them don't break. **Non-breaking**: the app gracefully ignores unknown `brand.*` params and already-deployed embeds keep working — passing `secondary`/`text` is simply a no-op going forward.

### 2. Fix brand-color contrast across SDK chrome

While trimming the tokens I found several spots that painted a brand color but assumed a fixed (white) foreground, so a **light** brand color produced unreadable white-on-light content. Each now derives a contrasting foreground from the color's WCAG relative luminance (`readableTextColor`), falling back to prior behavior when the value isn't a parseable hex:

- **Popup/slider trigger button** — text color (was always the configured/default white).
- **Float launcher bubble** — icon (`currentColor`) color (CSS was hard-coded `color: white`); fixed in all three styling paths (initial, `update`, CDN post-fetch recolor).
- **Loading skeleton** — shimmer/border palette now chosen from the actual `brand.bg` luminance instead of the theme, so a dark `brand.bg` under a light theme (or vice versa) still shows visible shimmer.

## Changes

- `src/constants.ts` — `BRAND_KEYS` reduced to `primary`/`bg` (+ dark).
- `src/types.ts` — `BrandColors` centers on `primary?`/`bg?`; `secondary?`/`text?` retained as `@deprecated` no-ops.
- `src/iframe.ts` — stop forwarding `brand.secondary`/`brand.text`.
- `src/browser.ts`, `src/float.ts`, `src/loading.ts` — luminance-based foreground selection.
- `src/utils.ts` — new `relativeLuminance` + `readableTextColor` helpers (strict hex parsing).
- `README.md` — brand-token tables/examples updated.
- `e2e/fixtures/brand-contrast.html` — visual fixture exercising the real trigger-button styling path.
- `.changeset/trim-brand-tokens.md` — minor bump + notes.

## Testing

- `@perspective-ai/sdk`: typecheck clean, **405 tests passing** (added unit tests for the helpers, float bubble icon color, and loading palette selection).
- `@perspective-ai/sdk-react`: typecheck clean, **89 tests passing**.
- Verified the trigger-button fix end-to-end by screenshotting the live CDN bundle: black text on light primaries (`#ffe066`, `#00e0a4`, `#ffffff`, `#e5e7eb`), white on dark (`#7c3aed`, `#111827`).

## Release

Version bump + CHANGELOG are intentionally **not** done by hand — the changeset is committed so the repo's "Version Packages" release workflow generates them (both packages → `1.10.0`) on merge.

## Out of scope

No changes to the consuming app (`perspective-ai/codebase`); the app-side removal of `secondary`/`text` is already merged. The dependency bump can follow once this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EuWRnYBezeyDEdwkZ5bV7