### PR TITLE
feat(sdk): polished, fully overridable default appearance for the inline widget

### DIFF
--- a/.changeset/widget-card-default.md
+++ b/.changeset/widget-card-default.md
@@ -1,0 +1,32 @@
+---
+"@perspective-ai/sdk": minor
+"@perspective-ai/sdk-react": minor
+---
+
+Widget: polished default appearance with a non-breaking, fully overridable
+frame.
+
+A bare inline widget (`<div data-perspective-widget>` / `<Widget />` with no
+container sizing) now renders as a centered, framed card — border, rounded
+corners, soft shadow, a comfortable height, and a sensible max-width — so it
+looks finished with zero CSS. Previously it was an unstyled, full-bleed iframe
+that looked awkward on wide pages.
+
+Backward compatible: when the host has sized the container (a height, `flex`,
+`height: 100%`, etc.), the widget keeps filling it edge to edge with no framing,
+exactly as before.
+
+New `frame` config object (also a `<Widget frame={…} />` prop) controls the
+inline widget's layout and appearance:
+
+- `layout: "card" | "fill"` — force a mode regardless of detection (`"fill"`
+  restores the full-width behaviour; omit to auto-detect).
+- `maxWidth`, `minHeight`, `radius`, `border`, `shadow`, `background` — each
+  maps to a `--perspective-widget-*` CSS custom property the card reads, so the
+  same knob is reachable from the `frame` object, a stylesheet, or inline
+  `style`. Because the SDK only reads these vars, an override wins at any
+  specificity and isn't clobbered by global resets.
+
+Script-tag users get the same control declaratively via a packed
+`data-perspective-frame` attribute, mirroring `data-perspective-brand`:
+`data-perspective-frame="layout=fill,radius=4px,shadow=none,bg=#fff"`.

--- a/examples/vanilla-js/index.html
+++ b/examples/vanilla-js/index.html
@@ -27,12 +27,6 @@
         margin-top: 0;
         font-size: 1.25rem;
       }
-      .widget-container {
-        height: 500px;
-        border: 1px solid #e5e7eb;
-        border-radius: 8px;
-        overflow: hidden;
-      }
       button {
         background: #7c3aed;
         color: white;
@@ -57,9 +51,12 @@
       <h2>Widget Embed (Data Attributes)</h2>
       <p>
         Uses <code>data-perspective-widget</code> for automatic initialization.
+        The widget renders as a centered, framed card by default — no wrapper
+        styling required. Override the width with the
+        <code>--perspective-widget-max-width</code> CSS variable if you want it
+        wider or full-bleed.
       </p>
       <div
-        class="widget-container"
         data-perspective-widget="YOUR_RESEARCH_ID"
         data-perspective-params="source=example,page=demo"
       ></div>

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -210,9 +210,35 @@ import { Widget } from "@perspective-ai/sdk-react";
   researchId="your-research-id"
   onSubmit={() => console.log("Done!")}
   className="my-widget"
-  style={{ height: 600 }}
 />;
 ```
+
+#### Layout & styling (`frame`)
+
+A bare `<Widget />` renders as a **centered, framed card** by default (border,
+rounded corners, soft shadow, sensible width/height) — no CSS required. If you
+size the container yourself (a `height`, `flex`, `height: 100%`, …) it **fills
+that box edge to edge** with no framing, exactly like before.
+
+Use the `frame` prop to force a layout or restyle the card:
+
+```tsx
+// Force full-width (pre-card behaviour), or always frame
+<Widget researchId="…" frame={{ layout: "fill" }} /> // or "card"
+
+// Restyle the card — each field maps to a --perspective-widget-* CSS variable
+<Widget
+  researchId="…"
+  frame={{ radius: "4px", border: "1px solid #ddd", shadow: "none", maxWidth: "720px" }}
+/>
+```
+
+`frame` accepts `layout` (`"card" | "fill"`), `maxWidth`, `minHeight`, `radius`,
+`border`, `shadow`, and `background`. Equivalent CSS variables
+(`--perspective-widget-radius`, etc.) work too; a `frame` value takes precedence
+over a stylesheet variable. See the
+[core SDK README](https://www.npmjs.com/package/@perspective-ai/sdk#styling-the-frame)
+for the full table and precedence rules.
 
 ### Fullpage
 

--- a/packages/sdk-react/src/Widget.test.tsx
+++ b/packages/sdk-react/src/Widget.test.tsx
@@ -55,12 +55,15 @@ describe("Widget", () => {
     expect(container.tagName).toBe("DIV");
   });
 
-  it("has default minHeight of 500px", async () => {
+  it("does not force an inline height on the container by default", async () => {
+    // The widget's default height comes from the injected `.perspective-widget`
+    // stylesheet rule, not an inline style. Forcing inline sizing here would
+    // make every widget look "host-sized" and suppress the card default.
     render(<Widget researchId="test-research-id" />);
     await act(async () => {});
 
     const container = screen.getByTestId("perspective-widget");
-    expect(container.style.minHeight).toBe("500px");
+    expect(container.style.minHeight).toBe("");
   });
 
   it("accepts custom className", async () => {
@@ -111,6 +114,19 @@ describe("Widget", () => {
     expect(config.theme).toBe("dark");
     expect(config.host).toBe("https://custom.example.com");
     expect(config.onVisualReady).toBeTypeOf("function");
+  });
+
+  it("forwards the frame object to createWidget", async () => {
+    render(
+      <Widget
+        researchId="test-research-id"
+        frame={{ layout: "fill", radius: "4px" }}
+      />
+    );
+    await act(async () => {});
+
+    const [, config] = mockCreateWidget.mock.calls[0]!;
+    expect(config.frame).toEqual({ layout: "fill", radius: "4px" });
   });
 
   it("creates widget immediately on mount (no upfront config fetch)", async () => {

--- a/packages/sdk-react/src/Widget.tsx
+++ b/packages/sdk-react/src/Widget.tsx
@@ -32,6 +32,7 @@ export function Widget({
   brand,
   theme,
   host,
+  frame,
   disableJsonLdAttribution,
   onReady,
   onVisualReady,
@@ -70,6 +71,7 @@ export function Widget({
       brand,
       theme,
       host,
+      frame,
       disableJsonLdAttribution,
       onReady: stableOnReady,
       onVisualReady: stableOnVisualReady,
@@ -100,6 +102,7 @@ export function Widget({
     brand,
     theme,
     host,
+    frame,
     disableJsonLdAttribution,
     stableOnReady,
     stableOnVisualReady,
@@ -116,7 +119,7 @@ export function Widget({
       <div
         ref={containerRef}
         className={className}
-        style={{ minHeight: 500, ...style }}
+        style={style}
         data-testid="perspective-widget"
         {...divProps}
       />

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -52,6 +52,91 @@ const handle = createWidget(container, {
 });
 ```
 
+#### Sizing — two modes, picked automatically
+
+The widget adapts to whether **you** have sized its container:
+
+- **Bare drop-in** (no size on the container) → renders as a centered, framed
+  **card** (border, rounded corners, soft shadow, `max-width: 480px`,
+  `min-height: 640px`) so it looks finished with zero CSS.
+- **Host-sized container** (you give it a height, `flex`, a grid track,
+  absolute positioning, etc.) → the widget **fills the container exactly**, with
+  no card framing. This is the original behaviour and is ideal for full-bleed or
+  "full page" layouts (e.g. header + widget + footer):
+
+```html
+<header>…</header>
+<!-- sized by the host → fills it edge to edge, no card -->
+<div
+  data-perspective-widget="your-research-id"
+  style="height: calc(100vh - 120px)"
+></div>
+<footer>…</footer>
+```
+
+The widget's container and appearance are configured with the **`frame`**
+object. **Force a mode** when auto-detection isn't what you want — `"fill"`
+restores the full-width behaviour, `"card"` always frames:
+
+```ts
+createWidget(el, { researchId: "…", frame: { layout: "fill" } }); // or "card"
+```
+
+```tsx
+<Widget researchId="…" frame={{ layout: "fill" }} /> // @perspective-ai/sdk-react
+```
+
+```html
+<div data-perspective-widget="…" data-perspective-frame="layout=fill"></div>
+```
+
+#### Styling the frame
+
+Every visual aspect of the card is exposed three equivalent ways — pick
+whichever fits. They all resolve to the same CSS custom property:
+
+| Aspect     | `frame` field | CSS variable                      | Default            |
+| ---------- | ------------- | --------------------------------- | ------------------ |
+| Max width  | `maxWidth`    | `--perspective-widget-max-width`  | `480px`            |
+| Min height | `minHeight`   | `--perspective-widget-min-height` | `640px`            |
+| Border     | `border`      | `--perspective-widget-border`     | `1px solid` border |
+| Radius     | `radius`      | `--perspective-widget-radius`     | theme radius       |
+| Shadow     | `shadow`      | `--perspective-widget-shadow`     | soft shadow        |
+| Background | `background`  | `--perspective-widget-bg`         | theme background   |
+
+**Precedence** (highest → lowest): a field set via `frame` / `data-perspective-frame`
+(the SDK writes it as an inline variable on the wrapper) → your own
+`--perspective-widget-*` declaration in CSS → the built-in default. So a `frame`
+field overrides a stylesheet variable. For any field you _don't_ pass to
+`frame`, your CSS variable wins at **any specificity** — the SDK leaves that var
+unset, so there's nothing to out-specify and it isn't clobbered by global resets
+like Tailwind Preflight's `* { border-width: 0 }`.
+
+```tsx
+// 1) The frame object (config / React prop)
+<Widget researchId="…" frame={{ radius: "4px", shadow: "none" }} />
+```
+
+```html
+<!-- 2) Script tag — packed data attribute (same format as data-perspective-brand) -->
+<div
+  data-perspective-widget="…"
+  data-perspective-frame="radius=4px,shadow=none,layout=card"
+></div>
+```
+
+```css
+/* 3) Stylesheet — any selector, even :root */
+.perspective-widget {
+  --perspective-widget-radius: 4px;
+}
+```
+
+> Sizing the container (`height`, `flex`, `height: 100%`, …) switches to fill
+> mode automatically; `frame.layout` overrides that detection either way. Values
+> that contain commas (e.g. a multi-layer `box-shadow`) can't be packed into the
+> data attribute — use the CSS variable for those.
+
 ### Popup Modal
 
 ```typescript
@@ -535,6 +620,7 @@ For non-module environments, use the browser bundle:
 | Attribute                         | Description                                             |
 | --------------------------------- | ------------------------------------------------------- |
 | `data-perspective-widget`         | Inline widget embed                                     |
+| `data-perspective-frame`          | Widget frame: `"layout=fill,radius=4px,shadow=none,…"`  |
 | `data-perspective-popup`          | Popup trigger button                                    |
 | `data-perspective-slider`         | Slider trigger button                                   |
 | `data-perspective-float`          | Floating chat bubble                                    |

--- a/packages/sdk/e2e/embed.spec.ts
+++ b/packages/sdk/e2e/embed.spec.ts
@@ -85,6 +85,32 @@ test.describe("Script Tag Auto-Init", () => {
     expect(src).toContain("user=abc");
   });
 
+  test("resolves widget layout: card for bare, fill when host-sized", async ({
+    page,
+  }) => {
+    await page.goto("/widget-layout.html");
+
+    const bare = page.locator("#bare .perspective-widget");
+    const sized = page.locator("#sized .perspective-widget");
+    const forced = page.locator("#forced-fill .perspective-widget");
+    await expect(bare).toBeVisible();
+    await expect(sized).toBeVisible();
+    await expect(forced).toBeVisible();
+
+    // Bare drop-in → centered, framed card.
+    await expect(bare).toHaveClass(/perspective-widget-card/);
+
+    // Stylesheet height resolves to a real computed height → fill (no card).
+    // Guards the computed-height detection branch in a real browser, which
+    // jsdom/happy-dom can't exercise.
+    await expect(sized).not.toHaveClass(/perspective-widget-card/);
+
+    // Explicit layout=fill on a bare container overrides detection → fill,
+    // and the packed appearance var is still applied.
+    await expect(forced).not.toHaveClass(/perspective-widget-card/);
+    await expect(forced).toHaveCSS("--perspective-widget-radius", "4px");
+  });
+
   test("creates popup trigger from data-perspective-popup attribute", async ({
     page,
   }) => {

--- a/packages/sdk/e2e/fixtures/widget-layout.html
+++ b/packages/sdk/e2e/fixtures/widget-layout.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Widget Layout Test</title>
+    <style>
+      /* Sized via stylesheet — should resolve to FILL (no card framing). */
+      .sized {
+        height: 500px;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Bare drop-in (no size) → card -->
+    <div id="bare" data-perspective-widget="bare01"></div>
+
+    <!-- Stylesheet height → fill (exercises the computed-height branch) -->
+    <div id="sized" class="sized" data-perspective-widget="sized01"></div>
+
+    <!-- Bare, but forced to fill via the data attribute -->
+    <div
+      id="forced-fill"
+      data-perspective-widget="forced01"
+      data-perspective-frame="layout=fill,radius=4px"
+    ></div>
+
+    <script src="/sdk/perspective.global.js"></script>
+  </body>
+</html>

--- a/packages/sdk/src/browser.test.ts
+++ b/packages/sdk/src/browser.test.ts
@@ -484,6 +484,36 @@ describe("browser entry", () => {
       expect(document.querySelector("iframe[data-perspective]")).toBeTruthy();
     });
 
+    it("parses data-perspective-frame (brand-style) into the frame config", async () => {
+      document.body.innerHTML = `
+        <div
+          data-perspective-widget="frame-widget"
+          data-perspective-frame="layout=fill,radius=4px,shadow=none,bg=#fff"
+        ></div>
+      `;
+
+      autoInit();
+      await flushConfigFetch();
+
+      const wrapper = document.querySelector<HTMLElement>(
+        ".perspective-widget"
+      );
+      // layout=fill → no card framing
+      expect(wrapper?.classList.contains("perspective-widget-card")).toBe(
+        false
+      );
+      // visual keys → CSS variables on the wrapper
+      expect(
+        wrapper?.style.getPropertyValue("--perspective-widget-radius")
+      ).toBe("4px");
+      expect(
+        wrapper?.style.getPropertyValue("--perspective-widget-shadow")
+      ).toBe("none");
+      expect(wrapper?.style.getPropertyValue("--perspective-widget-bg")).toBe(
+        "#fff"
+      );
+    });
+
     it("calling autoInit twice does not duplicate widgets", async () => {
       document.body.innerHTML = `
         <div data-perspective-widget="test-widget"></div>

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -21,6 +21,7 @@ import type {
   EmbedConfig,
   EmbedHandle,
   FloatHandle,
+  FrameConfig,
   InternalEmbedConfig,
   ShowOnce,
   ThemeConfig,
@@ -250,6 +251,52 @@ function parseBrandAttr(attrValue: string | null): BrandColors | undefined {
 }
 
 /**
+ * Parse the widget frame from a data attribute, mirroring the brand format:
+ * "layout=fill,radius=4px,shadow=none,background=#fff". Keys accept kebab or
+ * camel case (and `bg` for background). Values containing commas (e.g. a
+ * multi-layer box-shadow) can't be expressed here — use the
+ * `--perspective-widget-*` CSS variable for those.
+ */
+function parseFrameAttr(attrValue: string | null): FrameConfig | undefined {
+  if (!attrValue) return undefined;
+
+  const frame: FrameConfig = {};
+  for (const pair of attrValue.split(",")) {
+    const [key, ...valueParts] = pair.trim().split("=");
+    const k = key?.trim();
+    const value = valueParts.join("=").trim();
+    if (!k || !value) continue;
+    switch (k) {
+      case "layout":
+        if (value === "fill" || value === "card") frame.layout = value;
+        break;
+      case "radius":
+        frame.radius = value;
+        break;
+      case "border":
+        frame.border = value;
+        break;
+      case "shadow":
+        frame.shadow = value;
+        break;
+      case "background":
+      case "bg":
+        frame.background = value;
+        break;
+      case "max-width":
+      case "maxWidth":
+        frame.maxWidth = value;
+        break;
+      case "min-height":
+      case "minHeight":
+        frame.minHeight = value;
+        break;
+    }
+  }
+  return Object.keys(frame).length > 0 ? frame : undefined;
+}
+
+/**
  * Extract brand config and theme from element attributes
  */
 function extractBrandConfig(
@@ -473,12 +520,14 @@ function autoInit(): void {
       if (researchId && !instances.has(researchId)) {
         const params = parseParamsAttr(el);
         const brandConfig = extractBrandConfig(el);
+        const frame = parseFrameAttr(el.getAttribute(DATA_ATTRS.frame));
         perfLog("SDK", "autoInit found widget", { researchId });
         mount(el, {
           researchId,
           type: "widget",
           params,
           ...brandConfig,
+          ...(frame && { frame }),
           disableJsonLdAttribution: el.hasAttribute(
             DATA_ATTRS.disableJsonLdAttribution
           ),

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -88,6 +88,7 @@ export const DATA_ATTRS = {
   showOnce: "data-perspective-show-once",
   disableClose: "data-perspective-disable-close",
   sliderMode: "data-perspective-slider-mode",
+  frame: "data-perspective-frame",
   launcherIcon: "data-perspective-launcher-icon",
   launcherStyle: "data-perspective-launcher-style",
   launcherClass: "data-perspective-launcher-class",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -74,6 +74,7 @@ export type {
   LauncherConfig,
   LauncherIcon,
   LauncherStyle,
+  FrameConfig,
 } from "./types";
 
 // Re-export commonly used constants and types

--- a/packages/sdk/src/styles.ts
+++ b/packages/sdk/src/styles.ts
@@ -68,6 +68,41 @@ export function injectStyles(): void {
       }
     }
 
+    /* Inline widget. The base layer fills the host container exactly — this is
+       the original, non-opinionated behaviour, used whenever the host has sized
+       the container (full-bleed / custom layouts). When the container is an
+       unsized drop-in, the SDK additionally applies perspective-widget-card
+       for a centered, framed card so it looks finished with zero CSS. Both
+       knobs are plain custom properties the host can override. */
+    .perspective-widget {
+      position: relative;
+      box-sizing: border-box;
+      width: 100%;
+      height: 100%;
+      min-height: var(--perspective-widget-min-height, 500px);
+    }
+
+    .perspective-widget.perspective-widget-card {
+      max-width: var(--perspective-widget-max-width, 480px);
+      margin-left: auto;
+      margin-right: auto;
+      min-height: var(--perspective-widget-min-height, 640px);
+      background: var(--perspective-widget-bg, var(--perspective-modal-bg));
+      color: var(--perspective-modal-text);
+      border: var(--perspective-widget-border, 1px solid var(--perspective-border));
+      border-radius: var(--perspective-widget-radius, var(--perspective-radius));
+      box-shadow: var(--perspective-widget-shadow, var(--perspective-shadow-lg));
+      overflow: hidden;
+    }
+
+    .perspective-widget iframe {
+      display: block;
+      width: 100%;
+      height: 100%;
+      min-height: inherit;
+      border: none;
+    }
+
     /* Scrollbar styling */
     .perspective-modal,
     .perspective-slider,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -80,6 +80,36 @@ export type LauncherIcon =
   | { url: string }
   | { svg: string };
 
+/**
+ * The inline widget's frame — the card-like container the SDK draws around the
+ * interview. Every field is applied by setting the matching CSS custom property
+ * on the widget wrapper, so each can equivalently be set via a stylesheet or
+ * inline `style`. The framing fields (`maxWidth`, `radius`, `border`, `shadow`,
+ * `background`) only take effect in card layout (a bare drop-in, or
+ * `layout: "card"`); `minHeight` applies in both card and fill layouts.
+ */
+export interface FrameConfig {
+  /**
+   * Layout. Omit to auto-detect: a bare drop-in renders as a centered, framed
+   * `"card"`; a container you've sized (height, flex, `height: 100%`, …) renders
+   * as `"fill"` — edge to edge, no framing. `"fill"` forces the full-width
+   * behaviour; `"card"` always frames.
+   */
+  layout?: "card" | "fill";
+  /** Card max width, e.g. `"720px"` or `"none"`. → `--perspective-widget-max-width` (default `480px`). Card layout only. */
+  maxWidth?: string;
+  /** Min height, e.g. `"720px"`. → `--perspective-widget-min-height` (default `640px` card, `500px` fill). Applies in both layouts. */
+  minHeight?: string;
+  /** Card `border-radius`, e.g. `"4px"`. → `--perspective-widget-radius`. */
+  radius?: string;
+  /** Card `border` shorthand, e.g. `"1px solid #ddd"` or `"none"`. → `--perspective-widget-border`. */
+  border?: string;
+  /** Card `box-shadow`, e.g. `"none"`. → `--perspective-widget-shadow`. */
+  shadow?: string;
+  /** Card `background`, e.g. `"#fff"`. → `--perspective-widget-bg`. */
+  background?: string;
+}
+
 /** Customization options for the float launcher button */
 export interface LauncherConfig {
   /** Button icon. 'default' uses built-in SVG (mic/chat based on channel).
@@ -128,6 +158,20 @@ export interface EmbedConfig {
    * viewports. Only used for slider-type embeds.
    */
   sliderMode?: "overlay" | "push";
+  /**
+   * The inline widget's frame — layout, sizing, and the card's border/radius/
+   * shadow/background. Only used for widget-type embeds.
+   *
+   * Each field maps to a `--perspective-widget-*` CSS custom property, so the
+   * same knob is reachable from JS/React (this object), a stylesheet, or inline
+   * `style`. Precedence, highest to lowest: a field set here (the SDK writes it
+   * as an inline variable on the wrapper) → your own `--perspective-widget-*`
+   * declaration in CSS → the built-in default. So a `frame` field overrides a
+   * stylesheet variable; conversely, for any field you DON'T set here, your CSS
+   * variable wins at any specificity (the SDK leaves that var unset, so it's
+   * never out-specified and survives global resets like Tailwind Preflight).
+   */
+  frame?: FrameConfig;
   /** When true, skips JSON-LD structured data injection into the parent page. Other attribution signals (data attributes, global metadata, HTML comments) remain active. */
   disableJsonLdAttribution?: boolean;
   /** Customize the floating launcher button appearance. Only used for float-type embeds. */

--- a/packages/sdk/src/widget.test.ts
+++ b/packages/sdk/src/widget.test.ts
@@ -30,6 +30,94 @@ describe("createWidget", () => {
     handle.unmount();
   });
 
+  it("applies the framed card class for a bare drop-in container", () => {
+    const handle = createWidget(container, {
+      researchId: "test-research-id",
+    });
+
+    const wrapper = container.querySelector(".perspective-embed-root");
+    // An unsized container gets the centered, framed card default. The visual
+    // defaults come from these classes in the injected stylesheet so host
+    // pages can override them with plain CSS.
+    expect(wrapper?.classList.contains("perspective-widget")).toBe(true);
+    expect(wrapper?.classList.contains("perspective-widget-card")).toBe(true);
+
+    handle.unmount();
+  });
+
+  it("fills the container (no card framing) when the host sized it", () => {
+    // Custom "full page" layouts size the container themselves; we must not
+    // collapse them into a centered card. An explicit height signals intent.
+    container.style.height = "600px";
+
+    const handle = createWidget(container, {
+      researchId: "test-research-id",
+    });
+
+    const wrapper = container.querySelector(".perspective-embed-root");
+    expect(wrapper?.classList.contains("perspective-widget")).toBe(true);
+    expect(wrapper?.classList.contains("perspective-widget-card")).toBe(false);
+
+    handle.unmount();
+  });
+
+  it("frame.layout:'fill' forces fill mode on a bare container", () => {
+    const handle = createWidget(container, {
+      researchId: "test-research-id",
+      frame: { layout: "fill" },
+    });
+
+    const wrapper = container.querySelector(".perspective-embed-root");
+    expect(wrapper?.classList.contains("perspective-widget-card")).toBe(false);
+
+    handle.unmount();
+  });
+
+  it("frame.layout:'card' forces the card even when the host sized it", () => {
+    container.style.height = "600px";
+
+    const handle = createWidget(container, {
+      researchId: "test-research-id",
+      frame: { layout: "card" },
+    });
+
+    const wrapper = container.querySelector(".perspective-embed-root");
+    expect(wrapper?.classList.contains("perspective-widget-card")).toBe(true);
+
+    handle.unmount();
+  });
+
+  it("applies frame appearance as CSS variables on the wrapper", () => {
+    const handle = createWidget(container, {
+      researchId: "test-research-id",
+      frame: {
+        radius: "4px",
+        border: "none",
+        shadow: "none",
+        background: "#fff",
+        maxWidth: "720px",
+        minHeight: "720px",
+      },
+    });
+
+    const wrapper = container.querySelector<HTMLElement>(
+      ".perspective-embed-root"
+    );
+    const style = wrapper!.style;
+    expect(style.getPropertyValue("--perspective-widget-radius")).toBe("4px");
+    expect(style.getPropertyValue("--perspective-widget-border")).toBe("none");
+    expect(style.getPropertyValue("--perspective-widget-shadow")).toBe("none");
+    expect(style.getPropertyValue("--perspective-widget-bg")).toBe("#fff");
+    expect(style.getPropertyValue("--perspective-widget-max-width")).toBe(
+      "720px"
+    );
+    expect(style.getPropertyValue("--perspective-widget-min-height")).toBe(
+      "720px"
+    );
+
+    handle.unmount();
+  });
+
   it("creates loading indicator", () => {
     const handle = createWidget(container, {
       researchId: "test-research-id",

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -77,6 +77,63 @@ function createExistingWidgetHandle(
   };
 }
 
+/**
+ * Has the host given the widget container an explicit width or height?
+ *
+ * The centered, framed card is only a default for a *bare* drop-in. The moment
+ * the host sizes the container — inline OR via a stylesheet / flex / grid
+ * layout — we fill it exactly and skip the card's max-width / min-height, so an
+ * embed that already lives in a sized box (e.g. a `height: 100%` / `h-full`
+ * child of a sized flex or grid parent, or `.container { height: 500px }`) keeps
+ * its existing full-bleed layout.
+ *
+ * Detection:
+ *  1. Inline width/height (incl. min/max), flex, aspect-ratio, or out-of-flow
+ *     positioning — covers `style="..."`, including `width: 100%`.
+ *  2. A *resolved* computed height: an empty block box is ~0px tall until we
+ *     fill it, so any real height means a stylesheet / flex / grid sized it
+ *     (this is how `height: 100%` / Tailwind `h-full` is picked up).
+ *
+ * This is a best-effort read of author intent at mount time, not a guarantee —
+ * e.g. a bare drop-in that happens to be a stretched flex-row child resolves to
+ * a height and reads as "sized". `frame.layout` is the explicit override when
+ * the detection guesses wrong, in either direction.
+ *
+ * We deliberately do NOT infer an author width by measuring against the parent:
+ * an empty flex/grid child collapses to ~0px wide, which would misfire and
+ * shrink a bare drop-in. Width set purely via stylesheet (no inline width, no
+ * height) is uncommon; size the container or use the CSS variables instead.
+ */
+function hostControlsLayout(container: HTMLElement): boolean {
+  const s = container.style;
+  if (
+    s.width ||
+    s.minWidth ||
+    s.maxWidth ||
+    s.height ||
+    s.minHeight ||
+    s.maxHeight ||
+    s.flex ||
+    s.flexBasis ||
+    s.flexGrow ||
+    s.aspectRatio ||
+    s.position === "absolute" ||
+    s.position === "fixed"
+  ) {
+    return true;
+  }
+
+  try {
+    // Author-set height (stylesheet / flex / grid / height:100%). A bare block
+    // box reports ~0px tall here, so any real height means the host sized it.
+    if (parseFloat(getComputedStyle(container).height) > 1) return true;
+  } catch {
+    /* getComputedStyle unavailable (extremely rare) */
+  }
+
+  return false;
+}
+
 export function createWidget(
   container: HTMLElement | null,
   config: InternalEmbedConfig
@@ -101,11 +158,39 @@ export function createWidget(
   injectStyles();
   ensureGlobalListeners();
 
-  // Create wrapper for positioning
+  // Create wrapper for positioning. Visual defaults live in the injected
+  // `.perspective-widget` stylesheet rules so host pages can override them
+  // with ordinary CSS. The opinionated card framing is applied when the layout
+  // resolves to "card": an explicit `frame.layout` always wins; otherwise we
+  // best-effort detect whether the host already controls the container's box
+  // (see hostControlsLayout) so existing full-bleed / custom-layout embeds keep
+  // filling their container.
+  const frame = config.frame;
+  const useCard = frame?.layout
+    ? frame.layout === "card"
+    : !hostControlsLayout(container);
+
   const wrapper = document.createElement("div");
-  wrapper.className = cn("perspective-embed-root", getThemeClass(config.theme));
-  wrapper.style.cssText =
-    "position:relative;width:100%;height:100%;min-height:500px;";
+  wrapper.className = cn(
+    "perspective-embed-root perspective-widget",
+    useCard && "perspective-widget-card",
+    getThemeClass(config.theme)
+  );
+
+  // Frame appearance maps 1:1 to CSS custom properties the card rule reads.
+  // Setting them inline here is equivalent to the host setting the same vars in
+  // CSS — it's just a friendlier surface for JS/React consumers.
+  if (frame) {
+    const setVar = (prop: string, value?: string) => {
+      if (value != null && value !== "") wrapper.style.setProperty(prop, value);
+    };
+    setVar("--perspective-widget-max-width", frame.maxWidth);
+    setVar("--perspective-widget-min-height", frame.minHeight);
+    setVar("--perspective-widget-radius", frame.radius);
+    setVar("--perspective-widget-border", frame.border);
+    setVar("--perspective-widget-shadow", frame.shadow);
+    setVar("--perspective-widget-bg", frame.background);
+  }
 
   // Create loading indicator with theme and brand colors
   const loading = createLoadingIndicator({
@@ -126,9 +211,8 @@ export function createWidget(
     config.brand,
     config.theme
   );
-  iframe.style.width = "100%";
-  iframe.style.height = "100%";
-  iframe.style.minHeight = "500px";
+  // Size/border come from the `.perspective-widget iframe` rule; opacity is
+  // toggled inline as the loading skeleton hands off to the live iframe.
   iframe.style.opacity = "0";
   iframe.style.transition = "opacity 0.15s ease";
 


### PR DESCRIPTION
## Summary

The inline **widget** embed previously rendered as an unstyled, full-bleed iframe with a short `min-height: 500px`. Dropped into a normal content column (e.g. a 1024px page) it looked awkward — a borderless block, content floating in empty side-gutters on wide pages, and a jarring full-width slab in dark mode.

It now renders as a **centered, framed card by default** (border, rounded corners, soft shadow, theme background, a comfortable height, and a sensible `max-width`) so a bare drop-in looks finished with **zero CSS**. The popup, slider, float, and fullpage types were already well-framed and are unchanged.

## Backward compatibility

When the host has **sized the container** — inline sizing, or a height resolved from a stylesheet / flex / grid (e.g. Tailwind `h-full` in a sized parent, or `.widget-container { height: 500px }`) — the widget **fills it edge to edge with no framing**, exactly as before.

## New `frame` object

Controls the inline widget's layout and appearance — a config field, a `frame` prop on the React `<Widget>`, and a packed `data-perspective-frame` attribute (mirroring `data-perspective-brand`):

```ts
createWidget(el, {
  researchId: "...",
  frame: {
    layout: "card", // or "fill"; omit to auto-detect ("fill" = pre-card full-width)
    maxWidth: "720px",
    minHeight: "720px",
    radius: "4px",
    border: "1px solid #ddd",
    shadow: "none",
    background: "#fff",
  },
});
```

```html
<div
  data-perspective-widget="ID"
  data-perspective-frame="layout=fill,radius=4px,shadow=none,bg=#fff"
></div>
```

### Fully overridable styling

Each appearance field maps to a CSS custom property the card reads, so the **same knob** is reachable from the `frame` object, the data attribute, a stylesheet, or inline `style`:

| Aspect     | `frame` field | CSS variable                      |
| ---------- | ------------- | --------------------------------- |
| Max width  | `maxWidth`    | `--perspective-widget-max-width`  |
| Min height | `minHeight`   | `--perspective-widget-min-height` |
| Border     | `border`      | `--perspective-widget-border`     |
| Radius     | `radius`      | `--perspective-widget-radius`     |
| Shadow     | `shadow`      | `--perspective-widget-shadow`     |
| Background | `background`  | `--perspective-widget-bg`         |

Precedence (highest → lowest): a field set via `frame` / `data-perspective-frame` (the SDK writes it as an inline variable on the wrapper) → your own `--perspective-widget-*` declaration in CSS → the built-in default. For any field you _don't_ pass to `frame`, your CSS variable wins at **any specificity** — the SDK leaves that var unset, so there's nothing to out-specify and it isn't clobbered by global resets like Tailwind Preflight's `* { border-width: 0 }`.

> The packed data attribute can't represent values containing commas (e.g. a multi-layer `box-shadow`) — those fall back to the CSS variable.

## Implementation notes

- Widget visual defaults moved from inline styles into injected `.perspective-widget` / `.perspective-widget.perspective-widget-card` stylesheet rules.
- `hostControlsLayout()` decides card-vs-fill when `frame.layout` is omitted, using inline sizing + a _resolved_ computed height (the fragile parent-width measurement was dropped — an empty flex/grid child collapses to ~0px and would misfire). It's a best-effort read of intent; `frame.layout` is the explicit override either way.
- The React `<Widget>` no longer forces an inline `minHeight` (height comes from CSS), so detection isn't fooled into always-fill.

## Testing

- Unit: 411 (sdk) + 90 (sdk-react) passing, incl. card/fill/override, CSS-variable, and `data-perspective-frame` parsing coverage.
- E2E (Playwright): 39 passing, incl. a real-browser layout test (bare → card, stylesheet-height → fill, explicit `layout=fill` → fill) that exercises the computed-height detection jsdom can't.
- typecheck / lint / format clean.
- Manual browser QA against **real** interview pages across desktop/laptop/tablet/mobile and light/dark, plus all styling/override paths (props, data attribute, CSS var, reset-robustness).

## Follow-up (separate repo)

Consumer-side updates for `Perspective-AI/codebase` (snippet generators, pinning existing sized usages to `frame.layout: "fill"`, docs) are tracked separately — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXRg4ghj2bosyTTR6tvzUK