### PR TITLE
feat(sdk): loading state = scene image + frosted card + circular loader

### DIFF
--- a/.changeset/generic-loading-skeleton.md
+++ b/.changeset/generic-loading-skeleton.md
@@ -1,0 +1,46 @@
+---
+"@perspective-ai/sdk": minor
+---
+
+Replace the loading skeleton with the interview's real chrome.
+
+Instead of a skeleton that mirrors the interview UI's internal layout (welcome
+card, message, input pill) — which drifts whenever that UI changes — the
+loading state now renders what the interview actually looks like from the
+outside in:
+
+- the research's **scene image** (fetched from
+  `{host}/interview/{researchId}/scene-image`) behind
+- a **frosted translucent card** (55% panel + backdrop blur, matching the
+  app's card treatment), with
+- a **circular loader** centered in the card (40px) — a conic-gradient arc
+  with a fading tail over a faint track, tinted with the brand primary
+  resolved with the SDK's usual precedence: local `brand.primary` override →
+  API embed config (`primaryColor` / `darkPrimaryColor`) → Perspective
+  default (`#7c3aed` / `#a78bfa`). As essential loading motion it is not
+  disabled by `prefers-reduced-motion`.
+
+The scene image is applied only after it has actually loaded, layered over
+the app's default surface color (`#f5f2f0` light, `#15171e` dark, or a custom
+`brand.bg`) — so a research without a scene (404), a slow network, or a
+blocked request cleanly degrades to a solid color.
+
+Because the loading state renders in the host page DOM (an overlay sibling of
+the cross-origin iframe), responsiveness is driven by CSS **container
+queries** on the slot the consumer provides — not viewport media queries. The
+card's sizing mirrors the interview app's own container queries (full-bleed
+below 672px width; a centered `max-width: 672px` box above it, with vertical
+padding stepping 4px → 48px → 80px at the app's 448px/768px container-height
+breakpoints), so the card doesn't jump at handoff. Breakpoints are in px, not
+the app's rem: the overlay lives in the host page, so rem would resolve against
+the host's (uncontrolled) root font-size, whereas the card must match the
+iframe's fixed pixels.
+
+`LoadingOptions` gains optional `researchId` and `host` (used for the scene
+URL) and `apiConfig` (used for the loader tint); all embed types pass them
+automatically.
+
+A new `prefetchSceneImage(researchId, host?)` export warms the scene image on
+intent signals — the SDK wires it to float-bubble hover/focus and to
+`data-perspective-popup`/`-slider` trigger elements — so deferred embeds open
+with the scene already cached.

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -41,6 +41,7 @@ import {
   markShown,
 } from "./triggers";
 import { createWidget } from "./widget";
+import { prefetchSceneImage } from "./loading";
 import { openPopup } from "./popup";
 import { openSlider } from "./slider";
 import { createFloatBubble, createChatBubble } from "./float";
@@ -692,6 +693,10 @@ function autoInit(): void {
           }
         });
         styleButton(el, DEFAULT_THEME, brandConfig);
+        // Warm the scene image on intent so it's cached when the embed opens.
+        const warmScene = () => prefetchSceneImage(researchId);
+        el.addEventListener("pointerenter", warmScene, { once: true });
+        el.addEventListener("focus", warmScene, { once: true });
         el.addEventListener("click", (e) => {
           e.preventDefault();
           // Cancel any pending API auto-trigger (manual open takes precedence)
@@ -772,6 +777,10 @@ function autoInit(): void {
           }
         });
         styleButton(el, DEFAULT_THEME, brandConfig);
+        // Warm the scene image on intent so it's cached when the embed opens.
+        const warmScene = () => prefetchSceneImage(researchId);
+        el.addEventListener("pointerenter", warmScene, { once: true });
+        el.addEventListener("focus", warmScene, { once: true });
         el.addEventListener("click", (e) => {
           e.preventDefault();
           // Cancel any pending API auto-trigger (manual open takes precedence)

--- a/packages/sdk/src/float.test.ts
+++ b/packages/sdk/src/float.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { createFloatBubble, createChatBubble } from "./float";
+import { prefetchSceneImage } from "./loading";
 import * as config from "./config";
 import { getPersistedOpenState, setPersistedOpenState } from "./state";
 
@@ -39,6 +40,21 @@ describe("createFloatBubble", () => {
     sessionStorage.clear();
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("prefetches the scene image on bubble hover", () => {
+    createFloatBubble({
+      researchId: "float-prefetch-test",
+      host: "https://s.getperspective.ai",
+    });
+    const bubble = document.querySelector(
+      ".perspective-float-bubble"
+    ) as HTMLElement;
+    bubble.dispatchEvent(new Event("pointerenter"));
+    // hover already kicked the fetch, so a manual prefetch is a dedup no-op
+    expect(
+      prefetchSceneImage("float-prefetch-test", "https://s.getperspective.ai")
+    ).toBeNull();
   });
 
   it("creates float bubble", () => {

--- a/packages/sdk/src/float.ts
+++ b/packages/sdk/src/float.ts
@@ -19,7 +19,7 @@ import {
   ensureGlobalListeners,
   ensureHostPreconnect,
 } from "./iframe";
-import { createLoadingIndicator } from "./loading";
+import { createLoadingIndicator, prefetchSceneImage } from "./loading";
 import { injectStyles, AUDIO_ICON, MESSAGES_ICON, CLOSE_ICON } from "./styles";
 import { getPersistedOpenState, setPersistedOpenState } from "./state";
 import {
@@ -519,6 +519,9 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
     const loading = createLoadingIndicator({
       theme: currentConfig.theme,
       brand: currentConfig.brand,
+      apiConfig: currentConfig._apiConfig,
+      researchId,
+      host,
     });
     loading.style.borderRadius = "16px";
 
@@ -531,8 +534,7 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
       currentConfig.brand,
       currentConfig.theme
     );
-    iframe.style.opacity = "0";
-    iframe.style.transition = "opacity 0.15s ease";
+    iframe.style.opacity = "0"; // snaps visible at handoff — see widget.ts
 
     floatWindow.appendChild(closeBtn);
     floatWindow.appendChild(loading);
@@ -616,6 +618,11 @@ export function createFloatBubble(config: InternalEmbedConfig): FloatHandle {
 
     currentConfig.onClose?.();
   };
+
+  // Warm the scene image on intent so it's cached when the window opens.
+  const warmScene = () => prefetchSceneImage(researchId, host);
+  bubble.addEventListener("pointerenter", warmScene, { once: true });
+  bubble.addEventListener("focus", warmScene, { once: true });
 
   // Toggle on bubble click
   bubble.addEventListener("click", () => {

--- a/packages/sdk/src/fullpage.ts
+++ b/packages/sdk/src/fullpage.ts
@@ -54,6 +54,9 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
+    apiConfig: config._apiConfig,
+    researchId,
+    host,
   });
   container.appendChild(loading);
 
@@ -66,8 +69,7 @@ export function createFullpage(config: InternalEmbedConfig): EmbedHandle {
     config.brand,
     config.theme
   );
-  iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.15s ease";
+  iframe.style.opacity = "0"; // snaps visible at handoff — see widget.ts
 
   container.appendChild(iframe);
   document.body.appendChild(container);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -28,7 +28,7 @@ export { openPopup } from "./popup";
 export { openSlider } from "./slider";
 export { createFloatBubble, createChatBubble } from "./float";
 export { createFullpage } from "./fullpage";
-export { createLoadingIndicator } from "./loading";
+export { createLoadingIndicator, prefetchSceneImage } from "./loading";
 
 // Auto-open triggers
 export {

--- a/packages/sdk/src/loading.test.ts
+++ b/packages/sdk/src/loading.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { createLoadingIndicator } from "./loading";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createLoadingIndicator, prefetchSceneImage } from "./loading";
+
+/** The shared stylesheet is injected once; read it back for assertions. */
+function injectedStyles(): string {
+  return (
+    document.getElementById("perspective-loading-styles")?.textContent ?? ""
+  );
+}
 
 describe("createLoadingIndicator", () => {
   beforeEach(() => {
@@ -8,6 +15,7 @@ describe("createLoadingIndicator", () => {
 
   afterEach(() => {
     document.body.innerHTML = "";
+    vi.unstubAllGlobals();
   });
 
   it("returns an element with perspective-loading class", () => {
@@ -15,126 +23,273 @@ describe("createLoadingIndicator", () => {
     expect(el.className).toBe("perspective-loading");
   });
 
-  it("renders header with logo and progress bar", () => {
+  it("renders scene layer, then content > frosted card > ring loader", () => {
     const el = createLoadingIndicator();
-    const header = el.children[0] as HTMLElement;
-    expect(header.children.length).toBe(2); // logo + progress bar
+    const scene = el.children[0] as HTMLElement;
+    expect(scene.className).toBe("perspective-loading__scene");
+    const content = el.children[1] as HTMLElement;
+    expect(content.className).toBe("perspective-loading__content");
+    const card = content.firstElementChild as HTMLElement;
+    expect(card.className).toBe("perspective-loading__card");
+    expect(card.children.length).toBe(1);
+    const ring = card.firstElementChild as HTMLElement;
+    expect(ring.className).toBe("perspective-loading__ring");
   });
 
-  it("renders welcome card with avatar, name, title, and body lines", () => {
-    const el = createLoadingIndicator();
-    const card = el.children[1] as HTMLElement;
-    expect(card.style.borderRadius).toBe("16px");
-    // Avatar row + title + 3 body lines = 5 children
-    expect(card.children.length).toBe(5);
-    // Avatar row has circle + name
-    const avatarRow = card.children[0] as HTMLElement;
-    const avatar = avatarRow.children[0] as HTMLElement;
-    expect(avatar.style.borderRadius).toBe("50%");
+  it("animates the ring via CSS keyframes (always — essential motion)", () => {
+    createLoadingIndicator();
+    const css = injectedStyles();
+    expect(css).toContain("@keyframes perspective-spin");
+    expect(css).toMatch(
+      /\.perspective-loading__ring\s*\{[^}]*animation:[^}]*perspective-spin/
+    );
+    // arc-only fallback declared before the color-mix track layer
+    expect(css).toMatch(
+      /background-image:\s*conic-gradient[^;]*;\s*background-image:\s*\n?\s*conic-gradient[\s\S]*color-mix/
+    );
+    // no reduced-motion override — a frozen spinner reads as hung
+    expect(css).not.toContain("@media (prefers-reduced-motion");
   });
 
-  it("renders chat message lines below card", () => {
-    const el = createLoadingIndicator();
-    const message = el.children[2] as HTMLElement;
-    // 2 text lines + icon = 3 children
-    expect(message.children.length).toBe(3);
+  it("sizes the ring at 40px", () => {
+    createLoadingIndicator();
+    expect(injectedStyles()).toMatch(
+      /\.perspective-loading__ring\s*\{[^}]*width:\s*40px/
+    );
   });
 
-  it("renders input area with pill button", () => {
-    const el = createLoadingIndicator();
-    const inputArea = el.children[3] as HTMLElement;
-    expect(inputArea.style.borderRadius).toBe("28px");
-    const pill = inputArea.firstElementChild as HTMLElement;
-    expect(pill.style.borderRadius).toBe("9999px");
+  it("builds the scene URL from host + researchId (encoded)", () => {
+    const el = createLoadingIndicator({
+      researchId: "pb b/vdh26",
+      host: "https://s.getperspective.ai",
+    });
+    const scene = el.children[0] as HTMLElement;
+    expect(scene.dataset.sceneUrl).toBe(
+      "https://s.getperspective.ai/interview/pb%20b%2Fvdh26/scene-image"
+    );
+    // not applied as a background until the image actually loads
+    expect(scene.style.backgroundImage).toBe("");
   });
 
-  it("does not render footer hint line", () => {
+  it("skips the scene image without researchId", () => {
     const el = createLoadingIndicator();
-    const footer = el.children[4] as HTMLElement;
-    expect(footer).toBeFalsy();
+    const scene = el.children[0] as HTMLElement;
+    expect(scene.dataset.sceneUrl).toBeUndefined();
+    expect(scene.style.backgroundImage).toBe("");
   });
 
-  it("shimmer elements have animation applied", () => {
-    const el = createLoadingIndicator();
-    const header = el.children[0] as HTMLElement;
-    const logo = header.firstElementChild as HTMLElement;
-    expect(logo.style.animation).toContain("perspective-shimmer");
+  it("normalizes the host to an origin (matches prefetch's dedupe key)", () => {
+    const el = createLoadingIndicator({
+      researchId: "path-host",
+      host: "https://s.getperspective.ai/some/path",
+    });
+    const scene = el.children[0] as HTMLElement;
+    expect(scene.dataset.sceneUrl).toBe(
+      "https://s.getperspective.ai/interview/path-host/scene-image"
+    );
+    // prefetch for the same research is now a dedupe no-op
+    expect(
+      prefetchSceneImage("path-host", "https://s.getperspective.ai")
+    ).toBeNull();
   });
 
-  it("uses light theme background by default", () => {
-    const el = createLoadingIndicator();
-    expect(el.style.background).toBe("#ffffff");
+  it("falls back to the default host when host is omitted", () => {
+    const el = createLoadingIndicator({ researchId: "no-host" });
+    const scene = el.children[0] as HTMLElement;
+    expect(scene.dataset.sceneUrl).toBe(
+      "https://getperspective.ai/interview/no-host/scene-image"
+    );
   });
 
-  it("uses dark theme background when specified", () => {
+  it("injects a stylesheet with the container query targeting descendants", () => {
+    createLoadingIndicator();
+    const css = injectedStyles();
+    // container-type: size (both axes) so height breakpoints match the app.
+    expect(css).toContain("container-type: size");
+    // px, not the app's rem — the overlay is in the host page (see loading.ts).
+    expect(css).toContain("@container (min-width: 672px)");
+    expect(css).not.toContain("@media (min-width");
+    // An element can't be styled by the container it establishes.
+    expect(css).toMatch(
+      /@container[^{]*\{\s*\.perspective-loading__content\s*\{/
+    );
+    expect(css).not.toMatch(/@container[^{]*\{\s*\.perspective-loading\s*\{/);
+  });
+
+  it("steps the card's vertical padding at the app's height breakpoints", () => {
+    createLoadingIndicator();
+    const css = injectedStyles();
+    // matched to the app: py-1 base, py-12 at @hsm (448px), py-20 at @hlg (768px)
+    expect(css).toMatch(
+      /@container \(min-width: 672px\) and \(min-height: 448px\)\s*\{\s*\.perspective-loading__content\s*\{\s*padding: 48px 4px/
+    );
+    expect(css).toMatch(
+      /@container \(min-width: 672px\) and \(min-height: 768px\)\s*\{\s*\.perspective-loading__content\s*\{\s*padding: 80px 4px/
+    );
+  });
+
+  it("frosts the card with the panel color and backdrop blur", () => {
+    createLoadingIndicator();
+    const css = injectedStyles();
+    expect(css).toMatch(
+      /\.perspective-loading__card\s*\{[^}]*background:\s*var\(--pl-panel\)/
+    );
+    expect(css).toContain("backdrop-filter: blur(22px)");
+  });
+
+  it("defaults to the app's light interview background", () => {
+    const el = createLoadingIndicator();
+    expect(el.style.background).toContain("#f5f2f0");
+    expect(el.style.getPropertyValue("--pl-panel")).toContain("255, 255, 255");
+  });
+
+  it("defaults to the app's dark interview background", () => {
     const el = createLoadingIndicator({ theme: "dark" });
-    expect(el.style.background).toBe("#02040a");
+    expect(el.style.background).toContain("#15171e");
+    expect(el.style.getPropertyValue("--pl-panel")).toContain("21, 23, 30");
   });
 
   it("uses brand bg color when provided", () => {
     const el = createLoadingIndicator({
       brand: { light: { bg: "#1a3a2a" } },
     });
-    expect(el.style.background).toBe("#1a3a2a");
+    expect(el.style.background).toContain("#1a3a2a");
   });
 
-  it("uses a dark shimmer/border palette for a dark brand bg under light theme", () => {
+  it("picks a dark panel palette for a dark brand bg under light theme", () => {
     const el = createLoadingIndicator({
       theme: "light",
       brand: { light: { bg: "#0a0a0a" } }, // dark bg despite light theme
     });
-    expect(el.style.background).toBe("#0a0a0a");
-    // Dark palette uses white-based translucent shimmer/borders so they stay visible
-    expect(el.innerHTML).toContain("rgba(255, 255, 255");
-    expect(el.innerHTML).not.toContain("rgba(0, 0, 0");
+    expect(el.style.background).toContain("#0a0a0a");
+    expect(el.style.getPropertyValue("--pl-panel")).toContain("21, 23, 30");
   });
 
-  it("uses a light shimmer/border palette for a light brand bg under dark theme", () => {
+  it("picks a light panel palette for a light brand bg under dark theme", () => {
     const el = createLoadingIndicator({
       theme: "dark",
       brand: { dark: { bg: "#fafafa" } }, // light bg despite dark theme
     });
-    expect(el.style.background).toBe("#fafafa");
-    expect(el.innerHTML).toContain("rgba(0, 0, 0");
-    expect(el.innerHTML).not.toContain("rgba(255, 255, 255");
+    expect(el.style.background).toContain("#fafafa");
+    expect(el.style.getPropertyValue("--pl-panel")).toContain("255, 255, 255");
   });
 
-  it("has column layout with padding", () => {
-    const el = createLoadingIndicator();
-    expect(el.style.flexDirection).toBe("column");
-    expect(el.style.padding).toBe("1.5rem");
-  });
-
-  it("hides logo when hideBranding is true", () => {
-    const el = createLoadingIndicator({ appearance: { hideBranding: true } });
-    // Header should only have progress bar, no logo
-    const header = el.children[0] as HTMLElement;
-    expect(header.children.length).toBe(1);
-  });
-
-  it("hides progress bar when hideProgress is true", () => {
-    const el = createLoadingIndicator({ appearance: { hideProgress: true } });
-    // Header should only have logo, no progress bar
-    const header = el.children[0] as HTMLElement;
-    expect(header.children.length).toBe(1);
-  });
-
-  it("hides entire header when both hideBranding and hideProgress", () => {
-    const defaultEl = createLoadingIndicator();
-    const hiddenEl = createLoadingIndicator({
-      appearance: { hideBranding: true, hideProgress: true },
+  describe("ring primary color precedence", () => {
+    it("defaults to the Perspective primary per theme", () => {
+      const light = createLoadingIndicator({ theme: "light" });
+      expect(light.style.getPropertyValue("--pl-primary")).toBe("#7c3aed");
+      const dark = createLoadingIndicator({ theme: "dark" });
+      expect(dark.style.getPropertyValue("--pl-primary")).toBe("#a78bfa");
     });
-    // One fewer child (no header section)
-    expect(hiddenEl.children.length).toBe(defaultEl.children.length - 1);
+
+    it("uses the API embed config primary when provided", () => {
+      const light = createLoadingIndicator({
+        theme: "light",
+        apiConfig: { primaryColor: "#0ea5e9", darkPrimaryColor: "#38bdf8" },
+      });
+      expect(light.style.getPropertyValue("--pl-primary")).toBe("#0ea5e9");
+      const dark = createLoadingIndicator({
+        theme: "dark",
+        apiConfig: { primaryColor: "#0ea5e9", darkPrimaryColor: "#38bdf8" },
+      });
+      expect(dark.style.getPropertyValue("--pl-primary")).toBe("#38bdf8");
+    });
+
+    it("local brand primary beats the API config", () => {
+      const el = createLoadingIndicator({
+        theme: "light",
+        brand: { light: { primary: "#e11d48" } },
+        apiConfig: { primaryColor: "#0ea5e9", darkPrimaryColor: "#38bdf8" },
+      });
+      expect(el.style.getPropertyValue("--pl-primary")).toBe("#e11d48");
+    });
+
+    it("falls back to default when API config omits the dark variant", () => {
+      const el = createLoadingIndicator({
+        theme: "dark",
+        apiConfig: { primaryColor: "#0ea5e9" },
+      });
+      expect(el.style.getPropertyValue("--pl-primary")).toBe("#a78bfa");
+    });
+
+    it("treats empty strings as unset, keeping theme-appropriate defaults", () => {
+      // empty brand falls through to the API config
+      const viaApi = createLoadingIndicator({
+        theme: "light",
+        brand: { light: { primary: "" } },
+        apiConfig: { primaryColor: "#0ea5e9" },
+      });
+      expect(viaApi.style.getPropertyValue("--pl-primary")).toBe("#0ea5e9");
+      // empty everything in dark theme → dark default, never the light one
+      const dark = createLoadingIndicator({
+        theme: "dark",
+        brand: { dark: { primary: "" } },
+        apiConfig: { darkPrimaryColor: "" },
+      });
+      expect(dark.style.getPropertyValue("--pl-primary")).toBe("#a78bfa");
+    });
   });
 
-  it("hides welcome card when hideGreeting is true", () => {
-    const el = createLoadingIndicator({ appearance: { hideGreeting: true } });
-    // Should have header, message, input, footer — no card
-    const children = Array.from(el.children);
-    const hasCard = children.some(
-      (c) => (c as HTMLElement).style.borderRadius === "16px"
+  it("lets callers override the root border radius (float/popup windows)", () => {
+    const el = createLoadingIndicator();
+    el.style.borderRadius = "16px";
+    const css = injectedStyles();
+    expect(el.style.borderRadius).toBe("16px");
+    expect(css).toMatch(/\.perspective-loading\s*\{[^}]*overflow:\s*hidden/);
+  });
+
+  it("accepts the deprecated appearance option and ignores it", () => {
+    const el = createLoadingIndicator({
+      appearance: {
+        hideBranding: true,
+        hideProgress: true,
+        hideGreeting: true,
+      },
+    });
+    // structure is unchanged — the loading state has no branding/progress/greeting
+    expect(el.querySelector(".perspective-loading__card")).toBeTruthy();
+    expect(el.querySelector(".perspective-loading__ring")).toBeTruthy();
+  });
+
+  it("prefetchSceneImage fetches once per URL and dedupes after", () => {
+    const url = prefetchSceneImage(
+      "prefetch-once",
+      "https://s.getperspective.ai"
     );
-    expect(hasCard).toBe(false);
+    expect(url).toBe(
+      "https://s.getperspective.ai/interview/prefetch-once/scene-image"
+    );
+    // second intent signal for the same research is a no-op
+    expect(
+      prefetchSceneImage("prefetch-once", "https://s.getperspective.ai")
+    ).toBeNull();
+  });
+
+  it("prefetchSceneImage is a no-op without a researchId", () => {
+    expect(prefetchSceneImage(undefined, "https://x.example")).toBeNull();
+  });
+
+  it("mounting the loading state marks its scene URL as already requested", () => {
+    createLoadingIndicator({
+      researchId: "mounted-first",
+      host: "https://s.getperspective.ai",
+    });
+    expect(
+      prefetchSceneImage("mounted-first", "https://s.getperspective.ai")
+    ).toBeNull();
+  });
+
+  it("bounds the dedupe set so it can't grow without limit", () => {
+    const host = "https://bound.getperspective.ai";
+    // Prefetch far more distinct research ids than the cap (50).
+    prefetchSceneImage("bounded-oldest", host);
+    for (let i = 0; i < 60; i++) prefetchSceneImage(`bounded-${i}`, host);
+    // The oldest entry was evicted, so it is no longer suppressed and
+    // re-prefetching it fires again (returns the URL rather than null).
+    expect(prefetchSceneImage("bounded-oldest", host)).toBe(
+      `${host}/interview/bounded-oldest/scene-image`
+    );
+    // A recent entry is still remembered (deduped).
+    expect(prefetchSceneImage("bounded-59", host)).toBeNull();
   });
 });

--- a/packages/sdk/src/loading.ts
+++ b/packages/sdk/src/loading.ts
@@ -1,30 +1,48 @@
 /**
- * Loading skeleton for embed iframes
+ * Loading overlay for embed iframes: the research's scene image behind a
+ * frosted card, with a circular loader centered in the card — the
+ * interview's stable chrome, not a skeleton that drifts when the app UI
+ * changes.
  *
- * Shows a skeleton that matches the conversation UI layout (welcome card +
- * input area) instead of a generic spinner. This makes the loading feel
- * faster because it sets visual expectations.
- *
- * SSR-safe - returns no-op on server
+ * Lives in the host page DOM (the iframe is cross-origin), so layout uses
+ * container queries on the consumer's slot, not viewport media queries.
+ * SSR-safe: no-op without a DOM.
  */
 
-import type { BrandColors, ThemeValue } from "./types";
-import { hasDom } from "./config";
+import type { BrandColors, ThemeConfig, ThemeValue } from "./types";
+import { hasDom, getHost } from "./config";
+import { DEFAULT_THEME } from "./embed-api";
 import { resolveTheme, readableTextColor } from "./utils";
 
-/** Default background + semi-transparent shimmer that works on any bg */
+/**
+ * Card layout breakpoints, matched to the interview app's container queries so
+ * the card doesn't jump at handoff. In px, not the app's rem: this overlay
+ * lives in the *host* page, so a rem breakpoint would resolve against the
+ * host's root font-size — which we don't control — while the iframe's card
+ * resolves against our app's (16px). px keeps the overlay locked to the
+ * iframe's fixed pixels regardless of the host. Browser zoom scales px too, so
+ * zoomed users still match; only a rare non-default browser font-size setting
+ * wouldn't (keep the interview root at 16px to stay exact there).
+ */
+const CARD_WIDTH_BP_PX = 672; // @2xl / max-w-2xl (42rem): full-bleed below, boxed at/above
+const CARD_H_BP_MID_PX = 448; // @hsm (28rem): py-1 (4px) -> py-12 (48px)
+const CARD_H_BP_LG_PX = 768; // @hlg (48rem): py-12 (48px) -> py-20 (80px)
+
+/**
+ * Matches the app's default surface (`bg-interview-bg`) and translucent card,
+ * so nothing flashes at handoff. `brand.bg` overrides the background; the
+ * panel palette follows the background's luminance (see getLoadingColors).
+ */
 const DEFAULT_COLORS = {
   light: {
-    bg: "#ffffff",
-    shimmer: "rgba(0, 0, 0, 0.06)",
-    shimmerHighlight: "rgba(0, 0, 0, 0.10)",
-    border: "rgba(0, 0, 0, 0.08)",
+    bg: "#f5f2f0",
+    panel: "rgba(255, 255, 255, 0.55)",
+    panelBorder: "rgba(0, 0, 0, 0.08)",
   },
   dark: {
-    bg: "#02040a",
-    shimmer: "rgba(255, 255, 255, 0.08)",
-    shimmerHighlight: "rgba(255, 255, 255, 0.13)",
-    border: "rgba(255, 255, 255, 0.08)",
+    bg: "#15171e",
+    panel: "rgba(21, 23, 30, 0.55)",
+    panelBorder: "rgba(255, 255, 255, 0.08)",
   },
 };
 
@@ -36,7 +54,16 @@ export interface LoadingOptions {
     light?: BrandColors;
     dark?: BrandColors;
   };
-  /** Appearance overrides from API config */
+  /** Enables the scene image behind the card */
+  researchId?: string;
+  /** Embed host for the scene URL (defaults via getHost) */
+  host?: string;
+  /** API embed config — loader tint fallback when `brand.primary` is unset */
+  apiConfig?: Partial<ThemeConfig>;
+  /**
+   * @deprecated Ignored — resolved server-side, and the loading state renders
+   * none of these. Kept so existing TS callers compile.
+   */
   appearance?: {
     hideBranding?: boolean;
     hideProgress?: boolean;
@@ -44,46 +71,195 @@ export interface LoadingOptions {
   };
 }
 
-/** Get colors for loading skeleton based on theme and brand */
 function getLoadingColors(options?: LoadingOptions): {
   bg: string;
-  shimmer: string;
-  shimmerHighlight: string;
-  border: string;
+  panel: string;
+  panelBorder: string;
+  primary: string;
 } {
   const theme = resolveTheme(options?.theme);
   const isDark = theme === "dark";
   const brandColors = isDark ? options?.brand?.dark : options?.brand?.light;
   const bg = brandColors?.bg;
 
-  // Choose the shimmer/border palette from the actual background luminance when
-  // a brand bg is set, so a dark brand.bg under a light theme (or vice versa)
-  // still gets visible shimmer and borders. readableTextColor returns white for
-  // dark backgrounds; fall back to the theme default for non-hex bg values.
+  // Tint precedence (same as the float launcher): brand → API config → default.
+  // `||`, not `??`, so empty strings fall through to the next source.
+  const api = options?.apiConfig;
+  const primary =
+    brandColors?.primary ||
+    (isDark ? api?.darkPrimaryColor : api?.primaryColor) ||
+    (isDark ? DEFAULT_THEME.darkPrimaryColor : DEFAULT_THEME.primaryColor);
+
+  // Panel palette follows the bg's luminance, so a dark brand.bg under a
+  // light theme still gets a readable card. Non-hex bg → theme default.
   const fg = bg ? readableTextColor(bg) : undefined;
   const useDarkPalette = fg ? fg === "#ffffff" : isDark;
   const defaults = useDarkPalette ? DEFAULT_COLORS.dark : DEFAULT_COLORS.light;
 
   return {
     bg: bg || defaults.bg,
-    shimmer: defaults.shimmer,
-    shimmerHighlight: defaults.shimmerHighlight,
-    border: defaults.border,
+    panel: defaults.panel,
+    panelBorder: defaults.panelBorder,
+    primary,
   };
 }
+function buildSceneUrl(researchId: string, host: string): string {
+  return `${host}/interview/${encodeURIComponent(researchId)}/scene-image`;
+}
 
-/** Inject shimmer keyframes once globally (shared across all embed instances) */
-let shimmerInjected = false;
-function injectShimmerKeyframes(): void {
-  if (shimmerInjected || !hasDom()) return;
-  shimmerInjected = true;
+/**
+ * Dedupes prefetch kick-offs. A mount still creates its own Image() — it
+ * needs the load event — but a prior prefetch makes it resolve from the
+ * browser cache, so nothing is fetched twice.
+ *
+ * Bounded so a long-lived SPA that surfaces many research ids can't grow it
+ * without limit; evicting the oldest only lets a very old URL be re-prefetched,
+ * which is harmless.
+ */
+const MAX_REMEMBERED_SCENE_URLS = 50;
+const requestedSceneUrls = new Set<string>();
+function rememberSceneUrl(url: string): void {
+  requestedSceneUrls.add(url);
+  if (requestedSceneUrls.size > MAX_REMEMBERED_SCENE_URLS) {
+    const oldest = requestedSceneUrls.values().next().value;
+    if (oldest !== undefined) requestedSceneUrls.delete(oldest);
+  }
+}
+
+/**
+ * Warm the scene image on intent signals (float-bubble hover, popup/slider
+ * triggers) so it's cached when the embed opens. 404 is harmless. Returns
+ * the URL, or null when skipped (no DOM/researchId, or already requested).
+ */
+export function prefetchSceneImage(
+  researchId?: string,
+  host?: string
+): string | null {
+  if (!hasDom() || !researchId) return null;
+  const sceneUrl = buildSceneUrl(researchId, getHost(host));
+  if (requestedSceneUrls.has(sceneUrl)) return null;
+  rememberSceneUrl(sceneUrl);
+  new Image().src = sceneUrl;
+  return sceneUrl;
+}
+
+/**
+ * Injected once — per-instance colors arrive as CSS custom properties on
+ * each root, so one stylesheet serves every embed.
+ */
+let stylesInjected = false;
+function injectStyles(): void {
+  if (stylesInjected || !hasDom()) return;
+  stylesInjected = true;
 
   const styleEl = document.createElement("style");
-  styleEl.id = "perspective-shimmer-keyframes";
+  styleEl.id = "perspective-loading-styles";
+  // Queries target descendants — an element can't be styled by the container
+  // it establishes. `container-type: size` (both axes) mirrors the app's
+  // `[container-type:size]` scene so the card's width AND height breakpoints
+  // match; the root has a definite size from its inset:0. Rounded float/popup
+  // windows are clipped by the root's overflow:hidden.
   styleEl.textContent = `
-    @keyframes perspective-shimmer {
-      0% { background-position: -400px 0; }
-      100% { background-position: 400px 0; }
+    .perspective-loading {
+      position: absolute;
+      inset: 0;
+      container-type: size;
+      overflow: hidden;
+      box-sizing: border-box;
+      transition: opacity 0.15s ease;
+      z-index: 1;
+    }
+    .perspective-loading__scene {
+      position: absolute;
+      inset: 0;
+      background-position: center;
+      background-size: cover;
+      background-repeat: no-repeat;
+      transform: scale(1.1);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+    .perspective-loading__content {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: stretch;
+      justify-content: center;
+      box-sizing: border-box;
+    }
+    .perspective-loading__card {
+      flex: 1 1 auto;
+      width: 100%;
+      box-sizing: border-box;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--pl-panel);
+      -webkit-backdrop-filter: blur(22px) saturate(1.15);
+      backdrop-filter: blur(22px) saturate(1.15);
+    }
+    /*
+     * Conic arc + faint track; ::after is the round cap at the leading edge
+     * (top). Plain conic-gradient first: browsers without color-mix() keep
+     * it as an arc-only fallback. No reduced-motion override — a frozen
+     * spinner reads as hung.
+     */
+    .perspective-loading__ring {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      position: relative;
+      background-image: conic-gradient(from 0turn, transparent 12%, var(--pl-primary));
+      background-image:
+        conic-gradient(from 0turn, transparent 12%, var(--pl-primary)),
+        linear-gradient(
+          color-mix(in srgb, var(--pl-primary) 16%, transparent),
+          color-mix(in srgb, var(--pl-primary) 16%, transparent)
+        );
+      -webkit-mask: radial-gradient(closest-side, transparent calc(100% - 4.5px), #000 calc(100% - 4px));
+      mask: radial-gradient(closest-side, transparent calc(100% - 4.5px), #000 calc(100% - 4px));
+      animation: perspective-spin 0.9s linear infinite;
+    }
+    .perspective-loading__ring::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 50%;
+      width: 4.5px;
+      height: 4.5px;
+      margin-left: -2.25px;
+      border-radius: 50%;
+      background: var(--pl-primary);
+    }
+    @keyframes perspective-spin {
+      to { transform: rotate(1turn); }
+    }
+    /*
+     * Card layout, matched to the interview app so the card doesn't jump at
+     * handoff. Boxed at the @2xl container width; vertical padding steps up at
+     * the @hsm/@hlg container heights (app: px-1/py-1 base, py-12, py-20).
+     * Horizontal padding stays 4px — the app's @3xl:px-12 is a no-op for card
+     * geometry (it only applies once the card is already capped and centered).
+     */
+    @container (min-width: ${CARD_WIDTH_BP_PX}px) {
+      .perspective-loading__content {
+        padding: 4px;
+      }
+      .perspective-loading__card {
+        max-width: ${CARD_WIDTH_BP_PX}px;
+        border: 1px solid var(--pl-panel-border);
+        border-radius: 16px;
+      }
+    }
+    @container (min-width: ${CARD_WIDTH_BP_PX}px) and (min-height: ${CARD_H_BP_MID_PX}px) {
+      .perspective-loading__content {
+        padding: 48px 4px;
+      }
+    }
+    @container (min-width: ${CARD_WIDTH_BP_PX}px) and (min-height: ${CARD_H_BP_LG_PX}px) {
+      .perspective-loading__content {
+        padding: 80px 4px;
+      }
     }
   `;
   document.head.appendChild(styleEl);
@@ -95,121 +271,46 @@ export function createLoadingIndicator(options?: LoadingOptions): HTMLElement {
     return { remove: () => {}, style: {} } as unknown as HTMLElement;
   }
 
-  injectShimmerKeyframes();
+  injectStyles();
 
   const colors = getLoadingColors(options);
-  const appearance = options?.appearance;
 
+  // Paints the bg instantly; callers may override borderRadius (float/popup).
   const container = document.createElement("div");
   container.className = "perspective-loading";
-  container.style.cssText = `
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
-    flex-direction: column;
-    background: ${colors.bg};
-    transition: opacity 0.15s ease;
-    z-index: 1;
-    overflow: hidden;
-    padding: 1.5rem;
-    box-sizing: border-box;
-  `;
+  container.style.background = colors.bg;
+  container.style.setProperty("--pl-panel", colors.panel);
+  container.style.setProperty("--pl-panel-border", colors.panelBorder);
+  container.style.setProperty("--pl-primary", colors.primary);
 
-  const shimmerBg = `linear-gradient(90deg, ${colors.shimmer} 25%, ${colors.shimmerHighlight} 50%, ${colors.shimmer} 75%)`;
-  const shimmer = (width: string, height: string): HTMLElement => {
-    const el = document.createElement("div");
-    el.style.cssText = `background:${shimmerBg};background-size:800px 100%;animation:perspective-shimmer 1.5s infinite linear;border-radius:8px;height:${height};width:${width};margin-bottom:0.5rem;`;
-    return el;
-  };
-
-  // -- Header: logo placeholder + progress bar --
-  if (!appearance?.hideBranding || !appearance?.hideProgress) {
-    const header = document.createElement("div");
-    header.style.cssText = `display:flex;flex-direction:column;align-items:center;gap:0.5rem;margin-bottom:1rem;`;
-    if (!appearance?.hideBranding) {
-      const logo = shimmer("7rem", "1.25rem");
-      logo.style.margin = "0 auto";
-      header.appendChild(logo);
-    }
-    if (!appearance?.hideProgress) {
-      const progressBar = shimmer("100%", "0.25rem");
-      progressBar.style.borderRadius = "9999px";
-      header.appendChild(progressBar);
-    }
-    container.appendChild(header);
+  // Scene applies only after load — a missing scene (404), slow network, or
+  // blocked request leaves the solid bg, never a broken paint.
+  const scene = document.createElement("div");
+  scene.className = "perspective-loading__scene";
+  if (options?.researchId) {
+    // getHost normalizes to an origin, matching prefetchSceneImage's dedupe key.
+    const sceneUrl = buildSceneUrl(options.researchId, getHost(options.host));
+    rememberSceneUrl(sceneUrl);
+    scene.dataset.sceneUrl = sceneUrl;
+    const img = new Image();
+    img.onload = () => {
+      scene.style.backgroundImage = `url("${sceneUrl}")`;
+      scene.style.opacity = "1";
+    };
+    img.src = sceneUrl;
   }
+  container.appendChild(scene);
 
-  // -- Welcome card: avatar + name, title, body lines --
-  if (!appearance?.hideGreeting) {
-    const card = document.createElement("div");
-    card.style.cssText = `border:1px solid ${colors.border};border-radius:16px;padding:1.25rem;margin-bottom:1.25rem;`;
-
-    // Avatar row: circle + name
-    const avatarRow = document.createElement("div");
-    avatarRow.style.cssText = `display:flex;align-items:center;gap:0.625rem;margin-bottom:0.875rem;`;
-    const avatar = shimmer("2.25rem", "2.25rem");
-    avatar.style.borderRadius = "50%";
-    avatar.style.flexShrink = "0";
-    avatar.style.marginBottom = "0";
-    const name = shimmer("6rem", "0.875rem");
-    name.style.marginBottom = "0";
-    avatarRow.appendChild(avatar);
-    avatarRow.appendChild(name);
-    card.appendChild(avatarRow);
-
-    // Title line
-    const title = shimmer("60%", "1.125rem");
-    title.style.marginBottom = "0.875rem";
-    card.appendChild(title);
-
-    // Body lines (3 lines — welcome message paragraph)
-    card.appendChild(shimmer("95%", "0.75rem"));
-    card.appendChild(shimmer("90%", "0.75rem"));
-    const lastBodyLine = shimmer("75%", "0.75rem");
-    lastBodyLine.style.marginBottom = "0";
-    card.appendChild(lastBodyLine);
-
-    container.appendChild(card);
-  }
-
-  // -- Chat message: greeting text + small icon --
-  const message = document.createElement("div");
-  message.style.cssText = `padding:0 0.25rem;margin-bottom:auto;`;
-  message.appendChild(shimmer("92%", "0.75rem"));
-  const msgLine2 = shimmer("50%", "0.75rem");
-  msgLine2.style.marginBottom = "0.75rem";
-  message.appendChild(msgLine2);
-  const icon = shimmer("1.5rem", "1.5rem");
-  icon.style.marginBottom = "0";
-  message.appendChild(icon);
-  container.appendChild(message);
-
-  // -- Input area: reply field + talk button pill --
-  const inputArea = document.createElement("div");
-  inputArea.style.cssText = `
-    margin-top: 1rem;
-    border: 1px solid ${colors.border};
-    border-radius: 28px;
-    height: 3rem;
-    padding: 0.375rem 0.375rem 0.375rem 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    box-sizing: border-box;
-  `;
-  const buttonPill = shimmer("4.5rem", "2.25rem");
-  buttonPill.style.borderRadius = "9999px";
-  buttonPill.style.marginBottom = "0";
-  inputArea.appendChild(buttonPill);
-  container.appendChild(inputArea);
-
-  // -- Footer: centered hint text --
-  // const footer = shimmer("14rem", "0.75rem");
-  // footer.style.margin = "0.75rem auto 0";
-  // container.appendChild(footer);
+  // Card: centered box on wide slots, full-bleed on compact (@container rule).
+  const content = document.createElement("div");
+  content.className = "perspective-loading__content";
+  const card = document.createElement("div");
+  card.className = "perspective-loading__card";
+  const ring = document.createElement("div");
+  ring.className = "perspective-loading__ring";
+  card.appendChild(ring);
+  content.appendChild(card);
+  container.appendChild(content);
 
   return container;
 }

--- a/packages/sdk/src/popup.ts
+++ b/packages/sdk/src/popup.ts
@@ -69,6 +69,9 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
+    apiConfig: config._apiConfig,
+    researchId,
+    host,
   });
   loading.style.borderRadius = "16px";
 
@@ -81,8 +84,7 @@ export function openPopup(config: InternalEmbedConfig): EmbedHandle {
     config.brand,
     config.theme
   );
-  iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.15s ease";
+  iframe.style.opacity = "0"; // snaps visible at handoff — see widget.ts
 
   modal.appendChild(closeBtn);
   modal.appendChild(loading);

--- a/packages/sdk/src/slider.ts
+++ b/packages/sdk/src/slider.ts
@@ -81,6 +81,9 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
+    apiConfig: config._apiConfig,
+    researchId,
+    host,
   });
 
   // Create iframe (hidden initially). Appearance overrides resolved server-side.
@@ -92,8 +95,7 @@ export function openSlider(config: InternalEmbedConfig): EmbedHandle {
     config.brand,
     config.theme
   );
-  iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.15s ease";
+  iframe.style.opacity = "0"; // snaps visible at handoff — see widget.ts
 
   slider.appendChild(closeBtn);
   slider.appendChild(loading);

--- a/packages/sdk/src/widget.ts
+++ b/packages/sdk/src/widget.ts
@@ -196,6 +196,9 @@ export function createWidget(
   const loading = createLoadingIndicator({
     theme: config.theme,
     brand: config.brand,
+    apiConfig: config._apiConfig,
+    researchId,
+    host,
   });
   wrapper.appendChild(loading);
 
@@ -211,10 +214,10 @@ export function createWidget(
     config.brand,
     config.theme
   );
-  // Size/border come from the `.perspective-widget iframe` rule; opacity is
-  // toggled inline as the loading skeleton hands off to the live iframe.
+  // Size/border come from the `.perspective-widget iframe` rule. At handoff
+  // the iframe snaps visible under the overlay's fade-out — no transition, so
+  // combined coverage never dips below 100% (a cross-fade would).
   iframe.style.opacity = "0";
-  iframe.style.transition = "opacity 0.15s ease";
 
   wrapper.appendChild(iframe);
   container.appendChild(wrapper);


### PR DESCRIPTION
## Summary

Replaces the embed loading skeleton with the interview's **real chrome**, rendered outside-in:

1. the research's **scene image** (from `{host}/interview/{researchId}/scene-image`) behind
2. a **frosted translucent card** (55% panel + `backdrop-filter: blur(22px)`, matching the app's card treatment), with
3. a **circular loader** centered in the card — a conic-gradient arc with a fading tail over a faint track, round cap at the leading edge.

## Details

- **Loader tint** follows the SDK's usual precedence (same as the float launcher): local `brand.primary` override → API embed config (`primaryColor` / `darkPrimaryColor`) → Perspective default (`#7c3aed` / `#a78bfa`). `LoadingOptions` gains `apiConfig`; all five embeds pass `_apiConfig` through. Empty strings fall through to the next source; browsers without `color-mix()` keep an arc-only fallback (the plain `conic-gradient` is declared first).
- **Scene image** is applied only after it has actually loaded, layered over the app's default surface color (`#f5f2f0` light / `#15171e` dark, or a custom `brand.bg`) — a research without a scene (404), slow network, or blocked request degrades to a clean solid color. `prefetchSceneImage()` warms it on intent signals (float-bubble hover/focus, popup/slider trigger elements), backed by a bounded (capped) dedupe set.
- **Container-query responsive, matched to the app.** The overlay lives in the host page DOM next to the cross-origin iframe, so layout keys off the consumer's slot via `container-type: size` (both axes) — not the viewport. The card's sizing mirrors the interview app's own container queries: full-bleed below **672px** width; a centered `max-width: 672px` box above it, with vertical padding stepping **4px → 48px → 80px** at the app's **448px / 768px** container-*height* breakpoints. Verified pixel-for-pixel against the live iframe across the full width×height grid, so the card doesn't jump at handoff. Breakpoints are in px, not the app's rem: rem would resolve against the host page's (uncontrolled) root font-size, whereas the card must match the iframe's fixed pixels.
- **Seamless handoff.** When the iframe signals `visual-ready`, it snaps to `opacity: 1` beneath the overlay (no transition) while the overlay fades out on top and is removed — so combined coverage never dips below 100% (a cross-fade would flash mid-fade).
- **Always animates**: a loading indicator is essential motion; a frozen spinner reads as hung (no `prefers-reduced-motion` override, which OS-level animation toggles also flip).

## Testing

- `packages/sdk` unit suite: **426 passed** (structure, scene URL building + normalization + 404 path, panel luminance palettes, loader tint precedence incl. empty-string fallthrough, container-query breakpoints, prefetch dedupe + bounded eviction).
- Typecheck, oxlint, prettier: clean.
- Verified in a real browser against the live interview iframe: card geometry matches the app pixel-for-pixel across the width×height breakpoint grid (including narrow-but-tall slots staying full-bleed); scene frosting on desktop; mobile full-bleed; API-config and local-brand tint; dark no-scene 404 fallback.
- Existing e2e specs depend only on the `.perspective-loading` root class (preserved) detaching at handoff.

## Requires (app-side, graceful until then)

`GET {host}/interview/{slug}/scene-image` — 302 to the versioned CDN asset (short-TTL redirect, immutable asset), 404 when the research has no scene. Until it ships, the loading state simply shows the solid background + card + loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)