### PR TITLE
Forward teaser.dismissible through FloatBubble/useFloatBubble

### DIFF
--- a/.changeset/float-teaser-dismissible-react.md
+++ b/.changeset/float-teaser-dismissible-react.md
@@ -1,0 +1,8 @@
+---
+"@perspective-ai/sdk-react": patch
+"@perspective-ai/sdk": patch
+---
+
+Forward the `teaser.dismissible` option through `FloatBubble` / `useFloatBubble` to the core SDK. The hook that stabilizes the teaser prop only carried `enabled`, `delay`, and `sound`, so it silently dropped `dismissible` — setting `teaser={{ dismissible: false }}` had no effect when using the React package (the × dismiss button still rendered). It is now forwarded alongside the other teaser fields.
+
+Also corrects the `EmbedConfig.teaser` JSDoc to list `dismissible` among the fields it controls. The vanilla config, CDN `data-perspective-teaser-dismissible` attribute, and core resolution already handled `dismissible` correctly; only the React wrapper was dropping it.

--- a/packages/sdk-react/src/hooks/useFloatBubble.test.ts
+++ b/packages/sdk-react/src/hooks/useFloatBubble.test.ts
@@ -64,6 +64,34 @@ describe("useFloatBubble", () => {
     expect(mockUnmount).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards all teaser fields to createFloatBubble", async () => {
+    const { unmount } = renderHook(() =>
+      useFloatBubble({
+        researchId: "test-research-id",
+        teaser: {
+          enabled: true,
+          delay: 2000,
+          sound: false,
+          dismissible: false,
+        },
+      })
+    );
+    await act(async () => {});
+
+    expect(mockCreateFloatBubble).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teaser: {
+          enabled: true,
+          delay: 2000,
+          sound: false,
+          dismissible: false,
+        },
+      })
+    );
+
+    unmount();
+  });
+
   it("returns expected interface", async () => {
     const { result, unmount } = renderHook(() =>
       useFloatBubble({ researchId: "test-research-id" })

--- a/packages/sdk-react/src/hooks/useFloatBubble.ts
+++ b/packages/sdk-react/src/hooks/useFloatBubble.ts
@@ -115,13 +115,19 @@ export function useFloatBubble(
   const teaserEnabled = teaser?.enabled;
   const teaserDelay = teaser?.delay;
   const teaserSound = teaser?.sound;
+  const teaserDismissible = teaser?.dismissible;
   const hasTeaser = teaser !== undefined;
   const stableTeaser = useMemo(
     (): EmbedConfig["teaser"] =>
       hasTeaser
-        ? { enabled: teaserEnabled, delay: teaserDelay, sound: teaserSound }
+        ? {
+            enabled: teaserEnabled,
+            delay: teaserDelay,
+            sound: teaserSound,
+            dismissible: teaserDismissible,
+          }
         : undefined,
-    [hasTeaser, teaserEnabled, teaserDelay, teaserSound]
+    [hasTeaser, teaserEnabled, teaserDelay, teaserSound, teaserDismissible]
   );
 
   // Resolve ReactNode icons to SVG strings for the core SDK

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -149,7 +149,7 @@ export interface EmbedConfig {
   channel?: AIAssistantChannel | AIAssistantChannel[] | null;
   /** Welcome message shown as a teaser bubble next to the float button. Only used for float-type embeds. */
   welcomeMessage?: string;
-  /** Controls if and when the welcome teaser appears (`enabled`, `delay`, `sound`). Only used for float-type embeds. */
+  /** Controls if and when the welcome teaser appears (`enabled`, `delay`, `sound`, `dismissible`). Only used for float-type embeds. */
   teaser?: TeaserConfig;
   /** Custom button text for popup/slider triggers */
   buttonText?: string;


### PR DESCRIPTION
## Problem

`1.15.0` added the `teaser.dismissible` option (the × button that lets a visitor dismiss the float teaser without opening the chat). The core `@perspective-ai/sdk` renders and honors it, but the React wrapper never forwards it, so `teaser={{ dismissible: false }}` has **no effect** when using `@perspective-ai/sdk-react` — the × button always renders.

The cause is in `useFloatBubble`, which stabilizes the teaser prop on its primitive fields (to avoid remounting the bubble on every parent render) and only carried three of them:

```js
// before — dismissible silently dropped
{ enabled: teaserEnabled, delay: teaserDelay, sound: teaserSound }
```

`dismissible` was never destructured, so it never reached `createFloatBubble`.

This surfaced downstream in the demos site, where `&teaser.dismissible=false` on the float/chat page had no effect despite the param being parsed and passed correctly.

## Fix

- **`packages/sdk-react/src/hooks/useFloatBubble.ts`** — destructure `teaser?.dismissible`, add it to the stabilized teaser object, and include it in the `useMemo` dependency array.
- **`packages/sdk-react/src/hooks/useFloatBubble.test.ts`** — new test asserting all four teaser fields (`enabled`, `delay`, `sound`, `dismissible`) are forwarded to `createFloatBubble`.

## Audit of the other teaser surfaces

Confirmed the React hook was the **only** surface dropping the field. Every other path already forwards `dismissible` and is test-covered:

| Surface | Status | Coverage |
|---|---|---|
| Vanilla config — `createFloatBubble({ teaser })` | ✅ correct (core `resolveTeaserConfig` spreads all fields) | `float.test.ts` |
| CDN data-attribute — `data-perspective-teaser-dismissible` | ✅ correct (parser reads all four attrs) | `browser.test.ts` |
| React — `<FloatBubble>` / `useFloatBubble` | ⚠️ was broken → fixed here | new test |

- **`packages/sdk/src/types.ts`** — the only remaining inaccuracy was the `EmbedConfig.teaser` JSDoc, which listed `enabled`/`delay`/`sound` but not `dismissible`; corrected so the documented API matches.

## Changeset

- **`.changeset/float-teaser-dismissible-react.md`** — `patch` bump for **both** `@perspective-ai/sdk-react` and `@perspective-ai/sdk` (the packages are `fixed`-linked).

## Verification

- Core `@perspective-ai/sdk` — `pnpm typecheck` clean, **455 tests pass**.
- `@perspective-ai/sdk-react` — `pnpm typecheck` clean, **91 tests pass** (including the new one).
- `pnpm build` succeeds and `dismissible` now appears in the compiled `dist/index.js`.
- Pre-commit/pre-push hooks (lint, format, test, typecheck across all packages) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)